### PR TITLE
Improve logging to associate it with a given build.

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -11,7 +11,7 @@ from glob import glob
 import subprocess
 from os import readlink
 import logging
-from logging import debug
+from logging import debug,error
 import time
 
 def format(s, **kwds):
@@ -87,11 +87,16 @@ if __name__ == "__main__":
   parser.add_argument("--debug", "-d", dest="debug", action="store_true", default=False)
   args = parser.parse_args()
   
+  logger = logging.getLogger()
+  logger_handler = logging.StreamHandler()
+  logger.addHandler(logger_handler)
+
   if args.debug:
-    logging.basicConfig(level=logging.DEBUG, format="%(levelname)s: %(message)s")
+    logger.setLevel(logging.DEBUG)
+    logger_handler.setFormatter(logging.Formatter('%(levelname)s: %(message)s'))
   else:
-    logging.basicConfig(level=logging.INFO)
-  
+    logger.setLevel(logging.INFO)
+
   # Setup build environment.
   if not args.action == "build":
     parser.error("Action %s unsupported" % args.action)
@@ -139,15 +144,35 @@ if __name__ == "__main__":
         if l.endswith("refs/heads/%s" % spec["tag"]):
           spec["commit_hash"] = l.split("\t", 1)[0]
           break
-      debug("Commit hash for %s@%s is %s" % (spec["source"], spec["tag"], spec["commit_hash"]))
-      # We emit an event for the main package, when encountered, so that we can
-      # use it to index builds of the same hash on different architectures.
-      if p in ["aliroot", "aliphysics", "o2"]:
-        debug("Main package is %s using %s@%s (%s)" % (p,
-                                                       spec["source"],
-                                                       spec["tag"],
-                                                       spec["commit_hash"]))
 
+  # Decide what is the main package we are building and at what commit.
+  #
+  # We emit an event for the main package, when encountered, so that we can use
+  # it to index builds of the same hash on different architectures. We also
+  # make sure add the main package and it's hash to the debug log, so that we
+  # can always extract it from it.
+  # If one of the special packages is in the list of packages to be built,
+  # we use it as main package, rather than the last one.
+  mainPackage = None
+  mainHash = None
+  for p in buildOrder:
+    spec = specs[p]
+    mainPackage = p
+    mainHash = spec["commit_hash"]
+    if p in ["aliroot", "aliphysics", "o2"]:
+      break
+  debug("Main package is %s@%s" % (mainPackage, mainHash))
+  if args.debug:
+    logger_handler.setFormatter(
+        logging.Formatter("%%(levelname)s:%s:%s: %%(message)s" % 
+                          (mainPackage, mainHash[0:8])))
+
+  # Now that we have the main package set, we can print out Useful information
+  # which we will be able to associate with this build.
+  for p in buildOrder:
+    spec = specs[p]
+    if "source" in spec:
+      debug("Commit hash for %s@%s is %s" % (spec["source"], spec["tag"], spec["commit_hash"]))
   # Calculate the hashes. We do this in build order so that we can guarantee
   # that the hashes of the dependencies are calculated first.
   debug("Calculating hashes.")
@@ -165,7 +190,6 @@ if __name__ == "__main__":
     h.update(str(spec.get("prepend_path", {})))
     requires = spec.get("requires", [])
     for dep in requires:
-      debug(dep)
       h.update(specs[dep]["hash"])
     if bool(spec.get("force_rebuild", False)):
       h.update(str(time.time()))


### PR DESCRIPTION
When using debug output, we now print out the "main package" and the hash used
for it. This will allow us to aggregate different builds of the same main
package, e.g. when building for different architectures or with different
version of some external (e.g., geant 4). This should simplify comparisons
and parsing with logstash.