### PR TITLE
Handle corner case with overlapping versions. Fix alisw/alidist#72.

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -399,8 +399,6 @@ if __name__ == "__main__":
     # - Remove it if we do not know its hash
     # - Use the latest number in the version, to decide its revision
     debug("Packages already built using this version\n%s" % "\n".join(packages))
-    if not packages:
-      spec["revision"] = 1
     busyRevisions = []
     for d in packages:
       realPath = readlink(d)
@@ -425,8 +423,10 @@ if __name__ == "__main__":
       else:
         busyRevisions.append(revision)
 
-    if not "revision" in spec:
+    if not "revision" in spec and busyRevisions:
       spec["revision"] = min(set(range(1, max(busyRevisions)+2)) - set(busyRevisions))
+    elif not "revision" in spec:
+      spec["revision"] = "1"
 
     # Now that we have all the information about the package we want to build, let's
     # check if it wasn't built / unpacked already.


### PR DESCRIPTION
There is a corner case when two packages have an overlapping version
which includes a -, say alice3 and alice3-xrd. If the latter was already
uploaded, the former will still think its revision is a possible
candidate, but will then fail to match later on, which is correct.
However if there is no other tarball available, we will end up crashing,
rather than simply assigning "1" as a revision.

This handles the problem by simply detecting the fact there is no
revision candidates and therefore picking 1.