### PR TITLE
Correctly detect the main package.

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -247,7 +247,7 @@ if __name__ == "__main__":
   # we use it as main package, rather than the last one.
   mainPackage = None
   mainHash = None
-  for p in buildOrder:
+  for p in reversed(buildOrder):
     spec = specs[p]
     mainPackage = p
     mainHash = spec["commit_hash"]


### PR DESCRIPTION
Previous mechanism was failing in case a main package was depending on another
like it's the case now for O2.