### PR TITLE
Fix PKGREVISION relocation undoing the actual path relocation.

### DIFF
--- a/build_template.sh
+++ b/build_template.sh
@@ -143,8 +143,7 @@ ORIGINAL_PKGPATH=${PKGPATH}
 PKGPATH=\${PKGPATH:-${PKGPATH}}
 EoF
 
-cat "$INSTALLROOT/.original-unrelocated" | xargs -n1 -I{} echo "sed -e \"s|/[^ ]*INSTALLROOT/$PKGHASH/\$ORIGINAL_PKGPATH|\$WORK_DIR/\$PKGPATH|g\" \$PKGPATH/{}.unrelocated > \$PKGPATH/{}" >> "$INSTALLROOT/relocate-me.sh"
-cat "$INSTALLROOT/.original-unrelocated" | xargs -n1 -I{} echo "sed -e \"s|[@][@]PKGREVISION[@]$PKGHASH[@][@]|$PKGREVISION|g\" \$PKGPATH/{}.unrelocated > \$PKGPATH/{}" >> "$INSTALLROOT/relocate-me.sh"
+cat "$INSTALLROOT/.original-unrelocated" | xargs -n1 -I{} echo "sed -e \"s|/[^ ]*INSTALLROOT/$PKGHASH/\$ORIGINAL_PKGPATH|\$WORK_DIR/\$PKGPATH|g;s|[@][@]PKGREVISION[@]$PKGHASH[@][@]|$PKGREVISION|g\" \$PKGPATH/{}.unrelocated > \$PKGPATH/{}" >> "$INSTALLROOT/relocate-me.sh"
 cat "$INSTALLROOT/.original-unrelocated" | xargs -n1 -I{} cp '{}' '{}'.unrelocated
 cd "$WORK_DIR/INSTALLROOT/$PKGHASH"
 


### PR DESCRIPTION
The `@@@PKGREVISION@<hash>@@` relocation, while correct, was replacing a file
which was already relocated with an old version. Fixed by doing both changes at
the same time.

<!---
@huboard:{"order":59.0,"milestone_order":59,"custom_state":""}
-->
