### PR TITLE
Introduce the concept of build_requires

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ The following entries are optional in the header:
     by `osx`.
     will make sure that IgProf is only built on architectures whose name does
     not begin with `osx`.
+  - `build_requires`: currently behaves just like `requires` with the exception
+    that packages in this list are not included in the dependency graph
+    produced by alideps.
   - `force_rebuild`: set it to `true` to force re-running the build recipe.
 
 ### The body

--- a/aliBuild
+++ b/aliBuild
@@ -182,6 +182,8 @@ if __name__ == "__main__":
       dieOnError(True, str(e))
     header, recipe = d.split("---", 1)
     spec = yaml.safe_load(header)
+    # For the moment we treat build_requires just as requires.
+    spec["requires"] = spec.get("requires", []) + spec.get("build_requires", [])
     # Check that version is a string
     dieOnError(not isinstance(spec["version"], basestring),
                "In recipe \"%s\": version must be a string" % p)


### PR DESCRIPTION
In the future build_requires will only be used if a package needs to be built.
For now we simply use it to distinguish between different kind of requires and
produce prettier dependencies plots.