### PR TITLE
Add tag_basename expansion for version value

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The following entries are mandatory in the header:
       - ```%(commit_hash)s```
       - ```%(short_hash)s```
       - ```%(tag)s```
+      - ```%(tag_basename)s```
       - ```%(year)s```
       - ```%(month)s```
       - ```%(hour)s```

--- a/aliBuild
+++ b/aliBuild
@@ -272,6 +272,7 @@ if __name__ == "__main__":
                              commit_hash=spec["commit_hash"],
                              short_hash=spec["commit_hash"][0:10],
                              tag=spec["tag"],
+                             tag_basename=basename(spec["tag"]),
                              **nowKwds)
 
   # Decide what is the main package we are building and at what commit.


### PR DESCRIPTION
Useful in case you are using tags like:

    alice/v5-34-18

for ROOT but you want it to be called:

    v5-34-18