### PR TITLE
Publish requires which are runtime only

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -198,7 +198,8 @@ if __name__ == "__main__":
     header, recipe = d.split("---", 1)
     spec = yaml.safe_load(header)
     # For the moment we treat build_requires just as requires.
-    spec["requires"] = spec.get("requires", []) + spec.get("build_requires", [])
+    spec["runtime_requires"] = spec.get("requires", [])
+    spec["requires"] = spec["runtime_requires"] + spec.get("build_requires", [])
     # Check that version is a string
     dieOnError(not isinstance(spec["version"], basestring),
                "In recipe \"%s\": version must be a string" % p)
@@ -366,15 +367,23 @@ if __name__ == "__main__":
     ]
     spec.update(dict([(x, format(y, **pkgSpec)) for (x, y) in tarSpecs]))
 
+  # We recursively calculate the full set of requires "full_requires"
+  # including build_requires and the subset of them which are needed at
+  # runtime "full_runtime_requires".
   for p in buildOrder:
     spec = specs[p]
     todo = [p]
     spec["full_requires"] = []
+    spec["full_runtime_requires"] = []
     while todo:
-      requires = specs[todo.pop(0)].get("requires", [])
+      i = todo.pop(0)
+      requires = specs[i].get("requires", [])
+      runTimeRequires = specs[i].get("runtime_requires", [])
       spec["full_requires"] += requires
+      spec["full_runtime_requires"] += runTimeRequires
       todo += requires
     spec["full_requires"] = set(spec["full_requires"])
+    spec["full_runtime_requires"] = set(spec["full_runtime_requires"])
 
   # We now iterate on all the packages, making sure we build correctly every
   # single one of them. This is done this way so that the second time we run we
@@ -496,6 +505,7 @@ if __name__ == "__main__":
       # register packages in Alien.
       createDistLinks(spec, args, "dist", "full_requires")
       createDistLinks(spec, args, "dist-direct", "requires")
+      createDistLinks(spec, args, "dist-runtime", "full_runtime_requires")
       buildOrder.pop(0)
       packageIterations = 0
       continue


### PR DESCRIPTION
When a remote store is specified, we also populate the toplevel
directory "dist-runtime" which contains only the packages which are
required at runtime. This is done so that we can avoid publishing things
like autotools and cmake on Alien.