### PR TITLE
Disable shell path caching

### DIFF
--- a/build_template.sh
+++ b/build_template.sh
@@ -3,6 +3,7 @@
 # Build script for %(pkgname)s -- automatically generated
 
 set -e
+set +h
 export WORK_DIR="${WORK_DIR_OVERRIDE:-%(workDir)s}"
 
 # From our dependencies


### PR DESCRIPTION
Bash caches executables in $PATH for faster retrieval: we disable it to prevent
intermittent problems when we need to use a just-built package that, for
instance, overrides a system tool already in the cache. The latter could get
invoked instead with caching on (which is the default in Bash).