### PR TITLE
Complain if --docker is used with -a osx.*

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -210,6 +210,9 @@ if __name__ == "__main__":
   if args.preferSystem and args.noSystem:
     parser.error("choose either --always-prefer-system or --no-system")
 
+  if args.docker and args.architecture.startswith("osx"):
+    parser.error("cannot use `-a %s` and --docker" % args.architecture)
+
   if args.disable:
     args.disable = args.disable.split(",")
   logger = logging.getLogger('alibuild')


### PR DESCRIPTION
Docker cannot run "osx" containers. This does not mean you cannot run
`--docker -a slc7_x86-64` or alikes on Mac.