### PR TITLE
Correctly relocate modulefile in devel mode

### DIFF
--- a/build_template.sh
+++ b/build_template.sh
@@ -154,8 +154,10 @@ PH=${PKGHASH}
 EoF
 
 cat "$INSTALLROOT/.original-unrelocated" | xargs -n1 -I{} echo "sed -e \"s|/[^ ]*INSTALLROOT/\$PH/\$OP|\$WORK_DIR/\$PP|g;s|[@][@]PKGREVISION[@]\$PH[@][@]|$PKGREVISION|g\" \$PP/{}.unrelocated > \$PP/{}" >> "$INSTALLROOT/relocate-me.sh"
-# Always relocate the modulefile so that it works also in devel mode.
-grep etc/modulefiles "$INSTALLROOT/.original-unrelocated" || echo "sed -i .forced-relocation -e \"s|[@][@]PKGREVISION[@]\$PH[@][@]|$PKGREVISION|g\" \$PP/etc/modulefiles/$PKGNAME" >> "$INSTALLROOT/relocate-me.sh"
+# Always relocate the modulefile (if present) so that it works also in devel mode.
+if [[ ! -s "$INSTALLROOT/.original-unrelocated" && -f "$INSTALLROOT/etc/modulefiles/$PKGNAME" ]]; then
+  echo "mv -f \$PP/etc/modulefiles/$PKGNAME \$PP/etc/modulefiles/${PKGNAME}.forced-relocation && sed -e \"s|[@][@]PKGREVISION[@]\$PH[@][@]|$PKGREVISION|g\" \$PP/etc/modulefiles/${PKGNAME}.forced-relocation > \$PP/etc/modulefiles/$PKGNAME" >> "$INSTALLROOT/relocate-me.sh"
+fi
 cat "$INSTALLROOT/relocate-me.sh"
 cat "$INSTALLROOT/.original-unrelocated" | xargs -n1 -I{} cp '{}' '{}'.unrelocated
 cd "$WORK_DIR/INSTALLROOT/$PKGHASH"


### PR DESCRIPTION
Same rationale as #153 but:

 - works if recipe does not provide a modulefile
 - works with all sed flavors (i.e. on Ubuntu, `-i` with extension is not
   supported)