### PR TITLE
Do not clean install root for devel packages

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -853,7 +853,8 @@ if __name__ == "__main__":
     if fileHash != spec["hash"]:
       if fileHash != "0":
         debug("Mismatch between local area and the one which I should build. Redoing.")
-      shutil.rmtree(dirname(hashFile), True)
+      if not spec["package"] in develPkgs:
+        shutil.rmtree(dirname(hashFile), True)
     else:
       # If we get here, we know we are in sync with whatever remote store.  We
       # can therefore create a directory which contains all the packages which


### PR DESCRIPTION
@ktf: incrementally building packages has the side effect of removing modulefiles, as they are created in the full recipe.

Not sure about this solution; this speeds up the incremental builds, however it might introduce inconsistencies too, _e.g._ when a file/library is removed in the source and it will still exist in the destination.

TBH I think that:

 - recipes should be changed instead, to put the modulefile to the install directory also in the incremental versions
 - if users want to speed up things, instead of using `aliBuild` (which always guarantees consistency) they should `cd $BUILDDIR && make install` manually

In practice I would **not** merge this, but you might find a reason why this is the way to go instead?