### PR TITLE
Handle detached checkout for devel packages.

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -647,6 +647,9 @@ if __name__ == "__main__":
             spec["devel_hash"] = spec["commit_hash"] + h.hexdigest()
             cmd = "cd %s && git rev-parse --abbrev-ref HEAD" % spec["source"]
             err, out = getstatusoutput(cmd)
+            if out == "HEAD":
+              err, out = getstatusoutput("cd %s && git rev-parse HEAD" % spec["source"])
+              out = out[0:10]
             if err:
               print "Error, unable to lookup changes in development package %s. Is it a git clone?" % spec["source"]
               exit(1)


### PR DESCRIPTION
Use `git-rev-parse` without `--abbrev-ref` if we are on a dangling
commit.