### PR TITLE
Add symlinks to latest-<develPrefix>

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -658,7 +658,9 @@ if __name__ == "__main__":
             if err:
               print "Error, unable to lookup changes in development package %s. Is it a git clone?" % spec["source"]
               exit(1)
-            spec["tag"] = args.develPrefix if "develPrefix" in args else out
+            if not "develPrefix" in args:
+              args.develPrefix = out
+            spec["tag"] = args.develPrefix
             spec["commit_hash"] = "0"
           break
 
@@ -911,6 +913,9 @@ if __name__ == "__main__":
         try:
           unlink(format("%(w)s/BUILD/%(p)s-latest",
                  w=workDir, p=spec["package"]))
+          if "develPrefix" in args:
+            unlink(format("%(w)s/BUILD/%(p)s-latest-%(dp)s",
+                   w=workDir, p=spec["package"], dp=args.develPrefix))
         except:
           pass
         try:
@@ -1021,10 +1026,15 @@ if __name__ == "__main__":
     else:
       cachedTarball = spec["cachedTarball"]
 
+    develPrefix = ""
+    if spec["package"] in develPkgs:
+      develPrefix = args.develPrefix
+
     cmd = format(cmd_raw,
                  can_delete = args.aggressiveCleanup,
                  dependencies=dependencies,
                  dependenciesInit=dependenciesInit,
+                 develPrefix=args.develPrefix,
                  environment=environment,
                  workDir=workDir,
                  configDir=abspath(args.configDir),

--- a/build_template.sh
+++ b/build_template.sh
@@ -17,6 +17,7 @@ export PKGREVISION="%(revision)s"
 export REQUIRES="%(requires)s"
 export BUILD_REQUIRES="%(build_requires)s"
 export RUNTIME_REQUIRES="%(runtime_requires)s"
+export DEVEL_PREFIX="%(develPrefix)s"
 
 export PKG_NAME="$PKGNAME"
 export PKG_VERSION="$PKGVERSION"
@@ -59,6 +60,9 @@ fi
 mkdir -p "$INSTALLROOT" "$BUILDROOT" "$BUILDDIR" "$WORK_DIR/INSTALLROOT/$PKGHASH/$PKGPATH"
 cd "$BUILDROOT"
 ln -snf $PKGHASH $WORK_DIR/BUILD/$PKGNAME-latest
+if [[ $DEVEL_PREFIX ]]; then
+  ln -snf $PKGHASH $WORK_DIR/BUILD/$PKGNAME-latest-$DEVEL_PREFIX
+fi
 
 # Reference statements
 %(referenceStatement)s
@@ -183,3 +187,6 @@ tar xzf "$WORK_DIR/TARS/$HASH_PATH/$PACKAGE_WITH_REV"
 [ "X$CAN_DELETE" = X1 ] && rm "$WORK_DIR/TARS/$HASH_PATH/$PACKAGE_WITH_REV"
 bash -ex "$ARCHITECTURE/$PKGNAME/$PKGVERSION-$PKGREVISION/relocate-me.sh"
 ln -snf $PKGVERSION-$PKGREVISION $ARCHITECTURE/$PKGNAME/latest
+if [[ $DEVEL_PREFIX ]]; then
+  ln -snf $PKGVERSION-$PKGREVISION $ARCHITECTURE/$PKGNAME/latest-$DEVEL_PREFIX
+fi


### PR DESCRIPTION
In order to differentiate between the various builds, we add an extra
symlink which keeps the develPrefix into account. This way you can find
the latest build on branch master via:

  <prefix>/<architecture>/<package>/latest-master