### PR TITLE
Change default version to LAST_TAG

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,10 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # https://packaging.python.org/en/latest/single_source_version.html
-    version='1.0.19',
+    #
+    # LAST_TAG is actually a placeholder which will be automatically replaced by 
+    # the release-alibuild pipeline in jenkins whenever we need a new release.
+    version='LAST_TAG',
 
     description='ALICE Build Tool',
     long_description=long_description,


### PR DESCRIPTION
The `release-alibuild` pipeline in Jenkins will replace this placeholder
with the correct version obtained from the current tag of the master
branch.