### PR TITLE
Improve architecture detection

### DIFF
--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -33,6 +33,16 @@ INCREMENTAL_BUILD_HASH=${INCREMENTAL_BUILD_HASH:-0}
 mkdir -p "$WORK_DIR/BUILD" "$WORK_DIR/SOURCES" "$WORK_DIR/TARS" \
          "$WORK_DIR/SPECS" "$WORK_DIR/INSTALLROOT"
 export BUILDROOT="$WORK_DIR/BUILD/$PKGHASH"
+case $ARCHITECTURE in
+  osx*)
+    export LIBENVNAME=DYLD_LIBRARY_PATH
+    export SONAME=dylib
+  ;;
+  *)
+    export LIBENVNAME=LD_LIBRARY_PATH
+    export SONAME=so
+  ;;
+esac
 
 # In case the repository is local, it means we are in development mode, so we
 # install directly in $WORK_DIR/$PKGPATH so that we can do make install


### PR DESCRIPTION
Now the helper for architecture detection is pure and has its own
unittest. This should make sure we do not inadvertly change the
architecture while trying to support a different one.