### PR TITLE
Change default interpreter from python to python2

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import os, logging, time, re, yaml, hashlib, argparse
 import sys, shutil, subprocess, socket
 from commands import getstatusoutput

--- a/aliDoctor
+++ b/aliDoctor
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import argparse
 import os, re
 from os.path import exists, abspath


### PR DESCRIPTION
If the user is using python3 as their default python interpreter, running aliBuild or aliDoctor causes a SyntaxError. Until universal python support is implemented, changing the 'python' executable to 'python2', as perscribed in [PEP 394](https://www.python.org/dev/peps/pep-0394/), will select the right version.