### PR TITLE
Improve architecture detection

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -9,6 +9,7 @@ from datetime import datetime
 from urllib2 import urlopen, URLError
 import ssl
 import json
+from alibuild_helpers.utilities import doDetectArch, format
 
 debug, error, warning, info, riemannStream = (None, None, None, None, None)
 
@@ -66,8 +67,6 @@ class RiemannStream(object):
         pass
     self.buffer = ""
 
-def format(s, **kwds):
-  return s % kwds
 
 def writeAll(fn, txt):
   f = open(fn, "w")
@@ -216,38 +215,16 @@ VALID_ARCHS_RE = ["slc[5-9]+_(x86-64|ppc64)",
 # FIXME: we should have a fallback for lsb_release, since platform.dist
 # is going away.
 def detectArch():
+  hasOsRelease = exists("/etc/os-release")
+  osReleaseLines = open("/etc/os-release").readlines() if hasOsRelease else []
   try:
     import platform
-    if platform.system() == "Darwin":
-      return "osx_x86-64"
-    distribution, version, flavour = platform.dist()
-    # If platform.dist does not return something sensible,
-    # let's try with /etc/os-release
-    if distribution not in ["Ubuntu", "redhat", "centos"] and exists("/etc/os-release"):
-      for x in open("/etc/os-release").readlines():
-        if not "=" in x:
-          continue
-        key, val = x.split("=", 1)
-        val = val.strip("\n \"")
-        if key == "ID":
-          distribution = val
-        if key == "VERSION_ID":
-          version = val
- 
-    if distribution == "Ubuntu":
-      version = version.split(".")
-      version = version[0] + version[1]
-    if distribution in ["redhat", "centos"]:
-      distribution = distribution.replace("centos","slc").replace("redhat","slc").lower()
- 
-    processor = platform.processor()
-    return format("%(d)s%(v)s_%(c)s",
-                  d=distribution.lower(),
-                  v=version.split(".")[0],
-                  c=platform.processor().replace("_", "-"))
+    platformTuple = platform.dist()
+    platformSystem = platform.system()
+    platformProcessor = platform.processor()
+    return doDetectArch(hasOsRelease, osReleaseLines, platformTuple, platformSystem, platformProcessor)
   except:
     return None
-  return None
 
 # Detect number of available CPUs. Fallback to 1.
 def detectJobs():

--- a/alibuild_helpers/__init__.py
+++ b/alibuild_helpers/__init__.py
@@ -1,1 +1,2 @@
 # Dummy file to package build_template.sh
+import utilities as utilities

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+def format(s, **kwds):
+  return s % kwds
+
+def doDetectArch(hasOsRelease, osReleaseLines, platformTuple, platformSystem, platformProcessor):
+  if platformSystem == "Darwin":
+    return "osx_x86-64"
+  distribution, version, flavour = platformTuple
+  # If platform.dist does not return something sensible,
+  # let's try with /etc/os-release
+  if distribution not in ["Ubuntu", "redhat", "centos"] and hasOsRelease:
+    for x in osReleaseLines:
+      if not "=" in x:
+        continue
+      key, val = x.split("=", 1)
+      val = val.strip("\n \"")
+      if key == "ID":
+        distribution = val
+      if key == "VERSION_ID":
+        version = val
+
+  if distribution.lower() == "ubuntu":
+    version = version.split(".")
+    version = version[0] + version[1]
+  if distribution in ["redhat", "centos"]:
+    distribution = distribution.replace("centos","slc").replace("redhat","slc").lower()
+
+  processor = platformProcessor
+  return format("%(d)s%(v)s_%(c)s",
+                d=distribution.lower(),
+                v=version.split(".")[0],
+                c=processor.replace("_", "-"))

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1,0 +1,62 @@
+import unittest
+import platform
+from alibuild_helpers.utilities import doDetectArch
+
+UBUNTU_1510_OS_RELEASE = """
+NAME="Ubuntu"
+VERSION="15.10 (Wily Werewolf)"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 15.10"
+VERSION_ID="15.10"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+"""
+
+LINUX_MINT_OS_RELEASE = """
+NAME="Ubuntu"
+VERSION="14.04.4 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.4 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+"""
+
+UBUNTU_1404_OS_RELEASE = """
+NAME="Ubuntu"
+VERSION="14.04.3 LTS, Trusty Tahr"
+ID=ubuntu
+ID_LIKE=debian
+PRETTY_NAME="Ubuntu 14.04.3 LTS"
+VERSION_ID="14.04"
+HOME_URL="http://www.ubuntu.com/"
+SUPPORT_URL="http://help.ubuntu.com/"
+BUG_REPORT_URL="http://bugs.launchpad.net/ubuntu/"
+"""
+
+architecturePayloads = [
+  ['osx_x86-64', False, [], ('','',''), 'Darwin', 'x86-64'],
+  ['slc5_x86-64', False, [], ('redhat', '5.XX', 'Boron'), 'Linux', 'x86-64'],
+  ['slc6_x86-64', False, [], ('centos', '6.X', 'Carbon'), 'Linux', 'x86-64'],
+  ['slc7_x86-64', False, [], ('centos', '7.X', 'Ptor'), 'Linux', 'x86-64'],
+  ['ubuntu1510_x86-64', False, [], ('Ubuntu', '15.10', 'wily'), 'Linux', 'x86-64'],
+  ['ubuntu1510_x86-64', True, UBUNTU_1510_OS_RELEASE.split("\n"), ('Ubuntu', '15.10', 'wily'), 'Linux', 'x86-64'],
+  ['ubuntu1510_x86-64', True, UBUNTU_1510_OS_RELEASE.split("\n"), ('', '', ''), 'Linux', 'x86-64'], # ANACONDA case
+  ['ubuntu1404_x86-64', True, UBUNTU_1404_OS_RELEASE.split("\n"), ('Ubuntu', '14.04', 'trusty'), 'Linux', 'x86-64'],
+  ['ubuntu1404_x86-64', True, UBUNTU_1404_OS_RELEASE.split("\n"), ('', '', ''), 'Linux', 'x86-64'],
+  ['ubuntu1404_x86-64', True, LINUX_MINT_OS_RELEASE.split("\n"), ('LinuxMint', '17.3', 'rosa'), 'Linux', 'x86-64'], # LinuxMint
+]
+
+class TestArchitectures(unittest.TestCase):
+  def test_osx(self):
+    for payload in architecturePayloads:
+      result, hasOsRelease, osReleaseLines, platformTuple, platformSystem, platformProcessor = payload
+      self.assertEqual(result, doDetectArch(hasOsRelease, osReleaseLines, platformTuple, platformSystem, platformProcessor))
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
Now the helper for architecture detection is pure and has its own
unittest. This should make sure we do not inadvertly change the
architecture while trying to support a different one.