### PR TITLE
Fix alienv q display on OSX

### DIFF
--- a/alienv
+++ b/alienv
@@ -223,7 +223,7 @@ case "$ACTION" in
   q|query)
     [[ -z "${ARGS[0]}" ]] && SEARCH_CMD=cat || SEARCH_CMD=( grep -iE "${ARGS[0]}" )
     exec $MODULECMD bash -t avail 2>&1 | grep -E '^[^/]+/[^/]+$' | grep -vE ':$' | \
-      "${SEARCH_CMD[@]}" | sed -e 's!^\([^/]\+\)/\([^/]\+\)$!VO_ALICE@\1::\2!'
+      "${SEARCH_CMD[@]}" | sed -e 's!^\([^/]*\)/\(.*\)$!VO_ALICE@\1::\2!'
   ;;
   avail)
     exec $MODULECMD bash avail


### PR DESCRIPTION
`alienv q` displayed package/version instead of VO_ALICE@package::version due to
a non-cross-compatible `sed` syntax.