### PR TITLE
Add push URL instead of changing pull too in init

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_install: |
 script: |
   set -e
   time alibuild/aliBuild --help
+  time alibuild/aliBuild -z test-init init zlib
+  pushd test-init/alidist && git status && popd
+  pushd test-init/zlib && git status && popd
   time alibuild/aliBuild build zlib --dry-run
   time alibuild/aliBuild --aggressive-cleanup --docker -a slc7_x86-64 -d build zlib
   time alibuild/aliBuild --aggressive-cleanup --docker -a ubuntu1510_x86-64 -d build zlib

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ before_install: |
   cd ..
   git clone -b IB/v5-06/next https://github.com/alisw/alidist
 script: |
+  set -e
   time alibuild/aliBuild --help
   time alibuild/aliBuild build zlib --dry-run
   time alibuild/aliBuild --aggressive-cleanup --docker -a slc7_x86-64 -d build zlib

--- a/aliBuild
+++ b/aliBuild
@@ -570,7 +570,7 @@ if __name__ == "__main__":
       debug("cloning %s%s for development" % (spec["package"], " version "+p["ver"] if p["ver"] else ""))
       updateReferenceRepos(args.referenceSources, spec["package"], spec)
       err = execute(format("git clone %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
-                           "cd %(cd)s && git remote set-url origin %(writeRepo)s",
+                           "cd %(cd)s && git remote set-url --push origin %(writeRepo)s",
                            readRepo=spec["source"],
                            writeRepo=writeRepo,
                            branch=" -b "+p["ver"] if p["ver"] else "",


### PR DESCRIPTION
This prevents using the `write_repo` when pulling, if for some reason user has no access to it.