### PR TITLE
Fix for multiple devel branches for the same pkg

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -852,6 +852,9 @@ if __name__ == "__main__":
                              defaults_upper=defaults_upper,
                              **nowKwds)
 
+    if spec["package"] in develPkgs and "develPrefix" in args and args.develPrefix != "ali-master":
+      spec["version"] = args.develPrefix
+
   # Decide what is the main package we are building and at what commit.
   #
   # We emit an event for the main package, when encountered, so that we can use
@@ -902,15 +905,12 @@ if __name__ == "__main__":
       h(specs[dep]["hash"])
     if bool(spec.get("force_rebuild", False)):
       h(str(time.time()))
-    if p in develPkgs:
-      if "incremental_recipe" in spec:
-        h(spec["incremental_recipe"])
-        incremental_hash = hashlib.sha1(spec["incremental_recipe"]).hexdigest()
-        spec["incremental_hash"] = "INCREMENTAL_BUILD_HASH=%s" % incremental_hash
-      else:
-        h(spec.get("devel_hash"))
-      if "develPrefix" in args:
-        h(args.develPrefix)
+    if spec["package"] in develPkgs and "incremental_recipe" in spec:
+      h(spec["incremental_recipe"])
+      incremental_hash = hashlib.sha1(spec["incremental_recipe"]).hexdigest()
+      spec["incremental_hash"] = "INCREMENTAL_BUILD_HASH=%s" % incremental_hash
+    elif p in develPkgs:
+      h(spec.get("devel_hash"))
     spec["hash"] = h.hexdigest()
     debug("Hash for recipe %s is %s" % (p, spec["hash"]))
 


### PR DESCRIPTION
* Multiple build directories
* Multiple installation directories

This aims to fix #212.

**NOTE:** not for merging, this is a proposal to be discussed as it might have some impact, and better solutions might exist.

What it does: overrides whatever `version:` was specified in the recipe _if and only if_ the following two conditions are met:

1. The package is in development mode
2. A development prefix was specified