### PR TITLE
Use commit_hash from local src for devel packages

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -714,6 +714,11 @@ def doMain():
           # We are in development mode, we need to rebuild if the commit hash
           # is different and if there are extra changes on to.
           if spec["package"] in develPkgs:
+            # Devel package: we get the commit hash from the checked source, not from remote.
+            cmd = "cd %s && git rev-parse HEAD" % spec["source"]
+            err, out = getstatusoutput(cmd)
+            dieOnError(err, "Unable to detect current commit hash.")
+            spec["commit_hash"] = out.strip()
             cmd = "cd %s && git diff -r HEAD && git status --porcelain" % spec["source"]
             h = Hasher()
             err = execute(cmd, h)


### PR DESCRIPTION
Development packages used a random `commit_hash`, which came from a remote head (`git ls-remote`) and not necessarily for the currently checked out branch. This was not a problem until #282 where we use this piece of information to determine whether it is necessary to rebuild a development package.

If we get this information from the remote only, it might happen that package rebuild is not triggered in case we don't have local modifications, and in case we are moving back and forth pushed commits via `git reset --hard`.