### PR TITLE
Use environment in place of templated magic

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -798,7 +798,7 @@ def doMain():
     if spec["package"] in develPkgs and "incremental_recipe" in spec:
       h(spec["incremental_recipe"])
       incremental_hash = hashlib.sha1(spec["incremental_recipe"]).hexdigest()
-      spec["incremental_hash"] = "INCREMENTAL_BUILD_HASH=%s" % incremental_hash
+      spec["incremental_hash"] = incremental_hash
     elif p in develPkgs:
       h(spec.get("devel_hash"))
     spec["hash"] = h.hexdigest()
@@ -1130,34 +1130,20 @@ def doMain():
       develPrefix = args.develPrefix if "develPrefix" in args else develPackageBranch
 
     cmd = format(cmd_raw,
-                 can_delete = args.aggressiveCleanup,
                  dependencies=dependencies,
                  dependenciesInit=dependenciesInit,
                  develPrefix=develPrefix,
-                 develHash=spec.get("devel_hash", ""),
-                 depsHash=spec.get("deps_hash", ""),
                  environment=environment,
                  workDir=workDir,
                  configDir=abspath(args.configDir),
-                 pkgname=spec["package"],
-                 hash=spec["hash"],
-                 incremental_hash=spec.get("incremental_hash", ""),
                  incremental_recipe=spec.get("incremental_recipe", ":"),
-                 version=spec["version"],
-                 revision=spec["revision"],
-                 architecture=args.architecture,
-                 jobs=args.jobs,
                  sourceDir=source and (dirname(source) + "/") or "",
                  sourceName=source and basename(source) or "",
-                 write_repo=spec.get("write_repo", source),
-                 tag=spec["tag"],
-                 commit_hash=commit_hash,
                  referenceStatement=referenceStatement,
-                 cachedTarball=cachedTarball,
                  requires=" ".join(spec["requires"]),
                  build_requires=" ".join(spec["build_requires"]),
-                 runtime_requires=" ".join(spec["runtime_requires"]),
-                 gzip=gzip())
+                 runtime_requires=" ".join(spec["runtime_requires"])
+                )
 
     commonPath = "%s/%%s/%s/%s/%s-%s" % (workDir,
                                          args.architecture,
@@ -1173,6 +1159,32 @@ def doMain():
     banner("Building %s@%s" % (spec["package"],
                                args.develPrefix if "develPrefix" in args and spec["package"]  in develPkgs
                                                 else spec["version"]))
+    # Define the environment so that it can be passed up to the
+    # actual build script
+    buildEnvironment = [
+      ("ARCHITECTURE", args.architecture),
+      ("BUILD_REQUIRES", " ".join(spec["build_requires"])),
+      ("CACHED_TARBALL", cachedTarball),
+      ("CAN_DELETE", args.aggressiveCleanup and "1" or ""),
+      ("COMMIT_HASH", commit_hash),
+      ("DEPS_HASH", spec.get("deps_hash", "")),
+      ("DEVEL_HASH", spec.get("devel_hash", "")),
+      ("DEVEL_PREFIX", develPrefix),
+      ("GIT_TAG", spec["tag"]),
+      ("MY_GZIP", gzip()),
+      ("INCREMENTAL_BUILD_HASH", spec.get("incremental_hash", "0")),
+      ("JOBS", args.jobs),
+      ("PKGHASH", spec["hash"]),
+      ("PKGNAME", spec["package"]),
+      ("PKGREVISION", spec["revision"]),
+      ("PKGVERSION", spec["version"]),
+      ("REQUIRES", " ".join(spec["requires"])),
+      ("RUNTIME_REQUIRES", " ".join(spec["runtime_requires"])),
+      ("WRITE_REPO", spec.get("write_repo", source)),
+    ]
+    # Add the extra environment as passed from the command line.
+    for e in [x.split("=", "1") for x in args.environment]:
+      buildEnvironment.append(e)
     # In case the --docker options is passed, we setup a docker container which
     # will perform the actual build. Otherwise build as usual using bash.
     if dockerImage:
@@ -1184,7 +1196,7 @@ def doMain():
 
       for devel in develPkgs:
         develVolumes += " -v $PWD/`readlink %s || echo %s`:/%s:ro " % (devel, devel, devel)
-      for env in args.environment:
+      for env in buildEnvironment:
         additionalEnv = "-e %s" % env
       for volume in args.volumes:
         additionalVolumes = "-v %s" % volume
@@ -1195,27 +1207,26 @@ def doMain():
               " %(develVolumes)s"
               " %(additionalEnv)s"
               " %(additionalVolumes)s"
-              " -e ARCHITECTURE=%(architecture)s"
               " -e GIT_REFERENCE_OVERRIDE=/mirror"
-              " -e JOBS=%(jobs)s"
               " %(overrideSource)s"
               " -e WORK_DIR_OVERRIDE=/sw"
               " %(image)s"
               " /bin/bash -e -x /build.sh",
               additionalEnv=additionalEnv,
               additionalVolumes=additionalVolumes,
-              architecture=args.architecture,
               develVolumes=develVolumes,
               workdir=abspath(args.workDir),
               image=dockerImage,
               mirrorVolume=mirrorVolume,
-              jobs=args.jobs,
               overrideSource=overrideSource,
               scriptDir=scriptDir)
       debug(dockerWrapper)
       err = execute(dockerWrapper)
     else:
       progress = ProgressPrint("%s is being built (use --debug for full output)" % spec["package"])
+      for k,v in buildEnvironment:
+        print (k,v)
+        os.environ[k] = str(v)
       err = execute("/bin/bash -e -x %s/build.sh 2>&1" % scriptDir,
                     printer=debug if args.debug or not sys.stdout.isatty() else progress)
       progress.end("failed" if err else "ok", err)

--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Build script for %(pkgname)s -- automatically generated
+# Automatically generated build script
 
 set -e
 set +h
@@ -9,29 +9,34 @@ export WORK_DIR="${WORK_DIR_OVERRIDE:-%(workDir)s}"
 # From our dependencies
 %(dependencies)s
 
-export CAN_DELETE="%(can_delete)s"
-export PKGNAME="%(pkgname)s"
-export PKGHASH="%(hash)s"
-export PKGVERSION="%(version)s"
-export PKGREVISION="%(revision)s"
-export REQUIRES="%(requires)s"
-export BUILD_REQUIRES="%(build_requires)s"
-export RUNTIME_REQUIRES="%(runtime_requires)s"
-export DEVEL_PREFIX="%(develPrefix)s"
-DEVEL_HASH="%(develHash)s"
-DEPS_HASH="%(depsHash)s"
+# The following environment variables are setup by
+# the aliBuild script itself
+#
+# - ARCHITECTURE
+# - BUILD_REQUIRES
+# - CACHED_TARBALL
+# - CAN_DELETE
+# - COMMIT_HASH
+# - DEPS_HASH
+# - DEVEL_HASH
+# - DEVEL_PREFIX
+# - GIT_TAG
+# - INCREMENTAL_BUILD_HASH
+# - JOBS
+# - PKGHASH
+# - PKGNAME
+# - PKGREVISION
+# - PKGVERSION
+# - REQUIRES
+# - RUNTIME_REQUIRES
+# - WRITE_REPO
 
 export PKG_NAME="$PKGNAME"
 export PKG_VERSION="$PKGVERSION"
 export PKG_BUILDNUM="$PKGREVISION"
 
-export ARCHITECTURE="%(architecture)s"
 export SOURCE0="${SOURCE0_DIR_OVERRIDE:-%(sourceDir)s}%(sourceName)s"
-export GIT_TAG="%(tag)s"
-export JOBS=${JOBS-%(jobs)s}
 export PKGPATH=${ARCHITECTURE}/${PKGNAME}/${PKGVERSION}-${PKGREVISION}
-%(incremental_hash)s
-INCREMENTAL_BUILD_HASH=${INCREMENTAL_BUILD_HASH:-0}
 mkdir -p "$WORK_DIR/BUILD" "$WORK_DIR/SOURCES" "$WORK_DIR/TARS" \
          "$WORK_DIR/SPECS" "$WORK_DIR/INSTALLROOT"
 export BUILDROOT="$WORK_DIR/BUILD/$PKGHASH"
@@ -44,15 +49,15 @@ if [ "${SOURCE0:0:1}" == "/" ]; then
 else
   export INSTALLROOT="$WORK_DIR/INSTALLROOT/$PKGHASH/$PKGPATH"
 fi
-export SOURCEDIR="$WORK_DIR/SOURCES/$PKGNAME/$PKGVERSION/%(commit_hash)s"
+export SOURCEDIR="$WORK_DIR/SOURCES/$PKGNAME/$PKGVERSION/$COMMIT_HASH"
 export BUILDDIR="$BUILDROOT/$PKGNAME"
 
 SHORT_TAG=${GIT_TAG:0:10}
 mkdir -p $(dirname $SOURCEDIR)
-if [[ %(commit_hash)s != ${GIT_TAG} && "${SHORT_TAG:-0}" != %(commit_hash)s ]]; then
+if [[ ${COMMIT_HASH} != ${GIT_TAG} && "${SHORT_TAG:-0}" != ${COMMIT_HASH} ]]; then
   GIT_TAG_DIR=${GIT_TAG:-0}
   GIT_TAG_DIR=${GIT_TAG_DIR//\//_}
-  ln -snf %(commit_hash)s "$WORK_DIR/SOURCES/$PKGNAME/$PKGVERSION/${GIT_TAG_DIR}"
+  ln -snf ${COMMIT_HASH} "$WORK_DIR/SOURCES/$PKGNAME/$PKGVERSION/${GIT_TAG_DIR}"
 fi
 rm -fr "$WORK_DIR/INSTALLROOT/$PKGHASH"
 # We remove the build directory only if we are not in incremental mode.
@@ -75,7 +80,7 @@ if [[ ! "$SOURCE0" == '' && "${SOURCE0:0:1}" != "/" && ! -d "$SOURCEDIR" ]]; the
   git clone ${GIT_REFERENCE:+--reference $GIT_REFERENCE} "$SOURCE0" "$SOURCEDIR"
   cd $SOURCEDIR
   git checkout "${GIT_TAG}"
-  git remote set-url --push origin %(write_repo)s
+  git remote set-url --push origin $WRITE_REPO
 elif [[ ! "$SOURCE0" == '' && "${SOURCE0:0:1}" == "/" ]]; then
   ln -snf $SOURCE0 $SOURCEDIR
 fi
@@ -84,7 +89,6 @@ mkdir -p "$SOURCEDIR"
 cd "$BUILDDIR"
 
 # Actual build script, as defined in the recipe
-CACHED_TARBALL=%(cachedTarball)s
 
 # This actually does the build, taking in to account shortcuts like
 # having a pre build tarball or having an incremental recipe (in the
@@ -112,7 +116,7 @@ else
   # files.
   rm -rf "$BUILDROOT/log"
   mkdir -p $WORK_DIR/TMP/$PKGHASH
-  %(gzip)s -dc $CACHED_TARBALL | tar -C $WORK_DIR/TMP/$PKGHASH -x
+  $MY_GZIP -dc $CACHED_TARBALL | tar -C $WORK_DIR/TMP/$PKGHASH -x
   mkdir -p $(dirname $INSTALLROOT)
   rm -rf $INSTALLROOT
   mv $WORK_DIR/TMP/$PKGHASH/$ARCHITECTURE/$PKGNAME/$PKGVERSION-* $INSTALLROOT
@@ -137,7 +141,7 @@ export ${BIGPKGNAME}_ROOT=$INSTALLROOT
 export ${BIGPKGNAME}_VERSION=$PKGVERSION
 export ${BIGPKGNAME}_REVISION=$PKGREVISION
 export ${BIGPKGNAME}_HASH=$PKGHASH
-export ${BIGPKGNAME}_COMMIT=%(commit_hash)s
+export ${BIGPKGNAME}_COMMIT=${COMMIT_HASH}
 EOF
 
 # Environment


### PR DESCRIPTION
This uses environment variables rather than template magic to generate
the actual build script. This is done for two different reasons:

- It streamlines the code, making normal builds and docker ones behave almost
  the same.
- It clearly separate context (the environment) from the build script,
  making the latter much more linear. This should allow us to move to more
  easily to a DAG of scripts, which can eventually be rearranged to be
  executed in parallel or checkpointed at different points of the build
  process (we could even add the ability to checkpoint inside a recipe).