### PR TITLE
Protect again aliBuild in alienv cornercase

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -307,6 +307,9 @@ def prunePaths(workDir):
       continue
     workDirEscaped = re.escape("%s" % workDir) + "[^:]*:?"
     os.environ[x] = re.sub(workDirEscaped, "", os.environ[x])
+  for x in list(os.environ.keys()):
+    if x.endswith("_VERSION") and x != "ALIBUILD_VERSION":
+      os.environ.pop(x)
 
 def doMain():
   os.environ["LANG"] = "C"


### PR DESCRIPTION
aliBuild was not protecting against previously setup environment under
some circunstances. This should make sure the build environment will
always override the one previously set.

Notice there might still be leaks of the user environment into the build
one, but to have a definitive solution for this we would need to move to
rely on modulefiles only.