### PR TITLE
Fix issue with wrong order of environment variables

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -16,6 +16,10 @@ from alibuild_helpers.utilities import format, getVersion, detectArch
 from alibuild_helpers.analytics import decideAnalytics, askForAnalytics, report_screenview, report_exception, report_event
 from alibuild_helpers.analytics import enable_analytics, disable_analytics
 import traceback
+if float('%d.%d' % sys.version_info[:2]) < 2.7:
+  from ordereddict import OrderedDict
+else:
+  from collections import OrderedDict
 
 def writeAll(fn, txt):
   f = open(fn, "w")
@@ -317,11 +321,21 @@ class SpecError(Exception):
 def validateSpec(spec):
   if not spec:
     raise SpecError("Empty recipe.")
-  if type(spec) != dict:
+  if type(spec) != OrderedDict:
     raise SpecError("Not a YAML key / value.")
   if not "package" in spec:
     raise SpecError("Missing package field in header.")
 
+def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+  class OrderedLoader(Loader):
+    pass
+  def construct_mapping(loader, node):
+    loader.flatten_mapping(node)
+    return object_pairs_hook(loader.construct_pairs(node))
+  OrderedLoader.add_constructor(
+    yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+    construct_mapping)
+  return yaml.load(stream, OrderedLoader)
 
 def parseRecipe(filename):
   try:
@@ -330,7 +344,7 @@ def parseRecipe(filename):
     dieOnError(True, str(e))
   try:
     header,recipe = d.split("---", 1)
-    spec = yaml.safe_load(header)
+    spec = ordered_load(header, yaml.SafeLoader)
     validateSpec(spec)
   except SpecError, e:
     error(("Malformed header for %s\n" + str(e)) % filename)


### PR DESCRIPTION
Reading the content of the header section of any recipe results in an arbitrary order of the variables
defined in the env section. Often this order is importatnt and should be the same as defined in the
env section of the header.
Add functionality which loads the content of the header section into a ordered dictionary such that
the order of the variables is preserved.
