### PR TITLE
Fix raw_input / input discrepancy

### DIFF
--- a/alibuild_helpers/analytics.py
+++ b/alibuild_helpers/analytics.py
@@ -10,8 +10,6 @@ from alibuild_helpers.log import debug, error, banner, info, logger_handler
 from os.path import exists, expanduser
 from os import unlink
 
-input = getattr(__builtins__, 'raw_input', input)
-
 def generate_analytics_id():
   getstatusoutput("mkdir -p  ~/.config/alibuild")
   err, output = getstatusoutput("uuidgen >  ~/.config/alibuild/analytics-uuid")
@@ -27,6 +25,9 @@ def askForAnalytics():
   banner("In order to improve user experience, aliBuild would like to gather "
          "analytics about your builds.\nYou can find all the details at:\n\n"
          "  https://github.com/alisw/alibuild/blob/master/ANALYTICS.md\n")
+  # raw_input and input are different between python 2 and 3
+  try: input = raw_input
+  except NameError: pass
   a = input("Is that ok for you [YES/no]? ")
   if a.strip() and a.strip().lower().startswith("n"):
     debug("User requsted disabling analytics.")


### PR DESCRIPTION
Python 2 and python 3 have different behaviors when it comes to
raw_input and input builtins. The previous approach was not working
correctly, while this seems to be ok.