### PR TITLE
Unify defaults / disable support in aliBuild / aliDoctor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,6 +41,9 @@ script: |
   time coverage run -a alibuild/aliBuild -c alibuild/tests/testdist build broken4 --no-system --disable GCC-Toolchain 2>&1 | grep "Malformed header"
   time coverage run -a alibuild/aliBuild -c alibuild/tests/testdist build broken5 --no-system --disable GCC-Toolchain 2>&1 | grep "Missing package"
   time coverage run -a alibuild/aliBuild -c alibuild/tests/testdist build broken6 --no-system --disable GCC-Toolchain 2>&1 | grep scanning
+  pushd alibuild
+    time coverage run -a tests/test_parseRecipe.py
+  popd
   time coverage run -a alibuild/aliBuild build zlib --no-system --disable GCC-Toolchain
   alibuild/alienv q
   alibuild/alienv setenv zlib/latest -c bash -c '[[ $LD_LIBRARY_PATH == */zlib/* ]]'

--- a/aliBuild
+++ b/aliBuild
@@ -18,7 +18,8 @@ import json
 import logging
 from alibuild_helpers.log import debug, error, warning, banner, info
 from alibuild_helpers.log import logger_handler, logger, LogFormatter, ProgressPrint, riemannStream
-from alibuild_helpers.utilities import format, getVersion, detectArch, dockerStatusOutput
+from alibuild_helpers.utilities import format, getVersion, detectArch, dockerStatusOutput, parseDefaults, readDefaults
+from alibuild_helpers.utilities import parseRecipe, getPackageList, getRecipeReader
 from alibuild_helpers.analytics import decideAnalytics, askForAnalytics, report_screenview, report_exception, report_event
 from alibuild_helpers.analytics import enable_analytics, disable_analytics
 import traceback
@@ -317,52 +318,6 @@ def prunePaths(workDir):
     if x.endswith("_VERSION") and x != "ALIBUILD_VERSION":
       os.environ.pop(x)
 
-class SpecError(Exception):
-  pass
-
-def validateSpec(spec):
-  if not spec:
-    raise SpecError("Empty recipe.")
-  if type(spec) != dict:
-    raise SpecError("Not a YAML key / value.")
-  if not "package" in spec:
-    raise SpecError("Missing package field in header.")
-
-
-def parseRecipe(filename, distdir=None):
-  m = re.search(r'^dist:(.*)@([^@]+)$', filename)
-  if m:
-    fn,gh = m.groups()
-    err,d = getstatusoutput(format("GIT_DIR=%(dist)s/.git git show %(gh)s:%(fn)s.sh",
-                                   dist=distdir, gh=gh, fn=fn.lower()))
-    dieOnError(err, format("Cannot read recipe %(fn)s from reference %(gh)s.\n" +
-                           "Make sure you run first (this will not alter your recipes):\n" +
-                           "  cd %(dist)s && git remote update -p && git fetch --tags",
-                           dist=distdir, gh=gh, fn=fn))
-    warning("Overriding %s from reference %s" % (fn,gh))
-  else:
-    try:
-      d = open(filename).read()
-    except IOError as e:
-      dieOnError(True, str(e))
-  try:
-    header,recipe = d.split("---", 1)
-    spec = yaml.safe_load(header)
-    validateSpec(spec)
-  except SpecError, e:
-    error(("Malformed header for %s\n" + str(e)) % filename)
-    exit(1)
-  except yaml.scanner.ScannerError, e:
-    error(("Unable to parse %s\n" + str(e)) % filename)
-    exit(1)
-  except yaml.parser.ParserError, e:
-    error(("Unable to parse %s\n" + str(e)) % filename)
-    exit(1)
-  except ValueError, e:
-    error("Unable to parse %s. Header missing." % filename)
-    exit(1)
-  return (spec, recipe)
-
 def doMain():
   for x in ["LANG", "LANGUAGE", "LC_ALL", "LC_COLLATE",
             "LC_CTYPE", "LC_MESSAGES", "LC_MONETARY",
@@ -511,7 +466,8 @@ def doMain():
         dest = args.configDir
       else:
         filename = "%s/%s.sh" % (args.configDir, p["name"].lower())
-        spec,_ = parseRecipe(filename)
+        err, spec, _ = parseRecipe(getRecipeReader(filename))
+        dieOnError(err, err)
         dest = join(setdir, spec["package"])
       writeRepo = spec.get("write_repo", spec.get("source"))
       dieOnError(not writeRepo, "Package %s has no source field and cannot be developed" % spec["package"])
@@ -597,33 +553,10 @@ def doMain():
   if dockerImage:
     args.develPrefix = "%s-%s" % (args.develPrefix, args.architecture) if "develPrefix" in args else args.architecture
 
-  defaultsFilename = "%s/defaults-%s.sh" % (args.configDir, args.defaults)
-  if not exists(defaultsFilename):
-    viableDefaults = ["- " + basename(x).replace("defaults-","").replace(".sh", "")
-                      for x in glob("%s/defaults-*.sh" % args.configDir)]
-    parser.error(format("Default `%(d)s' does not exists. Viable options:\n%(v)s",
-                 d=args.defaults or "<no defaults specified>",
-                 v="\n".join(viableDefaults)))
-
-  # Defaults are actually special packages. They can override metadata
-  # of any other package and they can disable other packages. For
-  # example they could decide to switch from ROOT 5 to ROOT 6 and they
-  # could disable alien for O2. For this reason we need to parse their
-  # metadata early and extract the override and disable data.
-  defaultsMeta, defaultsBody = parseRecipe(defaultsFilename)
-  for x in defaultsMeta.get("disable", []):
-    debug("Package %s has been disabled by current default." % x)
-  args.disable.extend(defaultsMeta.get("disable", []))
-  if type(defaultsMeta.get("overrides", {})) != dict:
-    error("overrides should be a dictionary")
-    exit(1)
-  overrides = {}
-  taps = {}
-  for k, v in defaultsMeta.get("overrides", {}).items():
-    f = k.split("@", 1)[0].lower()
-    if "@" in k:
-      taps[f] = "dist:"+k
-    overrides[f] = v
+  defaultsReader = lambda : readDefaults(args.configDir, args.defaults, parser.error)
+  (err, overrides, taps) = parseDefaults(args.disable,
+                                         defaultsReader, debug)
+  dieOnError(err, err)
 
   specDir = "%s/SPECS" % workDir
   if not exists(specDir):
@@ -640,63 +573,24 @@ def doMain():
                toolHash=getDirectoryHash(dirname(__file__)),
                distHash=os.environ["ALIBUILD_ALIDIST_HASH"]))
 
-  systemPackages = set()
-  ownPackages = set()
-  while packages:
-    p = packages.pop(0)
-    if p in specs:
-      continue
-    lowerPkg = p.lower()
-    filename = taps.get(lowerPkg, "%s/%s.sh" % (args.configDir, lowerPkg))
-    spec, recipe = parseRecipe(filename, args.configDir)
-    dieOnError(spec["package"].lower() != lowerPkg,
-               "%s.sh has different package field: %s" % (p, spec["package"]))
-
-    # If the package has overrides, we apply them.
-    if lowerPkg in overrides:
-      debug("Overrides for package %s: %s" % (spec["package"], overrides[lowerPkg]))
-      spec.update(overrides.get(lowerPkg, {}) or {})
-
-    # If --always-prefer-system is passed or if prefer_system is set to true
-    # inside the recipe, use the script specified in the prefer_system_check
-    # stanza to see if we can use the system version of the package.
-    if not args.noSystem and (args.preferSystem or re.match(spec.get("prefer_system", "(?!.*)"), args.architecture)):
-      cmd = spec.get("prefer_system_check", "false").strip()
-      err, output = dockerStatusOutput(cmd, dockerImage)
-      if not err:
-        systemPackages.update([spec["package"]])
-        args.disable.append(spec["package"])
-      else:
-        ownPackages.update([spec["package"]])
-
-    dieOnError(("system_requirement" in spec) and recipe.strip("\n\t "),
-               "System requirements %s cannot have a recipe" % spec["package"])
-    if re.match(spec.get("system_requirement", "(?!.*)"), args.architecture):
-      cmd = spec.get("system_requirement_check", "false")
-      err, output = dockerStatusOutput(cmd.strip(), dockerImage)
-      dieOnError(err, spec.get("system_requirement_missing",
-                               "%s not found on system" % spec["package"]))
-      args.disable.append(spec["package"])
-
-    if spec["package"] in args.disable:
-      continue
-
-    # For the moment we treat build_requires just as requires.
-    fn = lambda what: filterByArchitecture(args.architecture, spec.get(what, []))
-    spec["requires"] = [x for x in fn("requires") if not x in args.disable]
-    spec["build_requires"] = [x for x in fn("build_requires") if not x in args.disable]
-    if spec["package"] != "defaults-" + args.defaults:
-      spec["build_requires"].append("defaults-" + args.defaults)
-    spec["runtime_requires"] = spec["requires"]
-    spec["requires"] = spec["runtime_requires"] + spec["build_requires"]
-    # Check that version is a string
-    dieOnError(not isinstance(spec["version"], str),
-               "In recipe \"%s\": version must be a string" % p)
-    spec["tag"] = spec.get("tag", spec["version"])
-    spec["version"] = spec["version"].replace("/", "_")
-    spec["recipe"] = recipe.strip("\n")
-    specs[spec["package"]] = spec
-    packages += spec["requires"]
+  (systemPackages, ownPackages, failed) = getPackageList(packages=packages,
+                                         specs=specs,
+                                         configDir=args.configDir,
+                                         preferSystem=args.preferSystem,
+                                         noSystem=args.noSystem,
+                                         architecture=args.architecture,
+                                         disable=args.disable,
+                                         defaults=args.defaults,
+                                         dieOnError=dieOnError,
+                                         performPreferCheck=lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage),
+                                         performRequirementCheck=lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage),
+                                         overrides=overrides,
+                                         taps=taps,
+                                         log=debug)
+  if failed:
+    error("The following packages are system requirements and could not be found:\n\n- " + "\n- ".join(sorted(list(failed))))
+    error("\nPlease run:\n\n\taliDoctor %s\n\nto get a full diagnosis." % args.pkgname)
+    sys.exit(1)
 
   for x in specs.values():
     x["requires"] = [r for r in x["requires"] if not r in args.disable]

--- a/aliDoctor
+++ b/aliDoctor
@@ -11,7 +11,8 @@ except ImportError:
 import logging
 from alibuild_helpers.log import debug, error, banner, info, success, warning
 from alibuild_helpers.log import logger_handler, logger, LogFormatter, ProgressPrint
-from alibuild_helpers.utilities import getPackageList, format, detectArch
+from alibuild_helpers.utilities import getPackageList, format, detectArch, parseDefaults, readDefaults
+from alibuild_helpers.utilities import dockerStatusOutput
 import subprocess
 
 def execute(command):
@@ -30,12 +31,12 @@ def prunePaths(workDir):
     workDirEscaped = re.escape("%s" % workDir) + "[^:]*:?"
     os.environ[x] = re.sub(workDirEscaped, "", os.environ[x])
 
-def checkPreferSystem(spec, cmd, homebrew_replacement):
+def checkPreferSystem(spec, cmd, homebrew_replacement, dockerImage):
     if cmd == "false":
       debug("Package %s can only be managed via alibuild." % spec["package"])
       return (1, "")
     cmd = homebrew_replacement + cmd
-    err, out = execute(cmd)
+    err, out = dockerStatusOutput(cmd, dockerImage=dockerImage, executor=execute)
     if not err:
       success("Package %s will be picked up from the system." % spec["package"])
       for x in out.split("\n"):
@@ -52,12 +53,12 @@ def checkPreferSystem(spec, cmd, homebrew_replacement):
                    error="\n".join(["%s: %s" % (spec["package"],x) for x in out.split("\n")])))
     return (err, "")
 
-def checkRequirements(spec, cmd, homebrew_replacement):
+def checkRequirements(spec, cmd, homebrew_replacement, dockerImage):
     if cmd == "false":
       debug("Package %s is not a system requirement." % spec["package"])
       return (0, "")
     cmd = homebrew_replacement + cmd
-    err, out = execute(cmd)
+    err, out = dockerStatusOutput(cmd, dockerImage=dockerImage, executor=execute)
     if not err:
       success("Required package %s will be picked up from the system." % spec["package"])
       debug(cmd)
@@ -95,16 +96,29 @@ if __name__ == "__main__":
   parser.add_argument("-a", "--architecture", help="force architecture",
                       dest="architecture", default=detectArch())
   parser.add_argument("-c", "--config", help="path to alidist",
-                      dest="config", default="alidist")
+                      dest="configDir", default="alidist")
   parser.add_argument("-w", "--work-dir", help="path to work dir",
                       dest="workDir", default="workDir")
   parser.add_argument("-d", "--debug", help="Show also successful tests.",
                       dest="debug", action="store_true", default=False)
+  parser.add_argument("--defaults", default="release",
+                      dest="defaults", help="Specify default to use")
+  parser.add_argument("--disable", dest="disable", default=[],
+                      metavar="PACKAGE", action="append",
+                      help="Do not build PACKAGE and all its (unique) dependencies.")
+  parser.add_argument("--always-prefer-system", dest="preferSystem", default=False,
+                      action="store_true", help="Always use system packages when compatible")
+  parser.add_argument("--no-system", dest="noSystem", default=False,
+                      action="store_true", help="Never use system packages")
   parser.add_argument("packages", nargs="+", help="Package to test",
                       default=[])
+  parser.add_argument("--docker", dest="docker", action="store_true", default=False)
+  parser.add_argument("--docker-image", dest="dockerImage",
+                      help="Image to use in case you build with docker (implies --docker-image)")
+
   args = parser.parse_args()
-  if not exists(args.config):
-    parser.error("Wrong path to alidist specified: %s" % args.config)
+  if not exists(args.configDir):
+    parser.error("Wrong path to alidist specified: %s" % args.configDir)
 
   prunePaths(abspath(args.workDir))
 
@@ -120,6 +134,11 @@ if __name__ == "__main__":
   if err:
     homebrew_replacement = "brew() { true; }; "
 
+
+  dockerImage = args.dockerImage if "dockerImage" in args else ""
+  if args.docker and not dockerImage:
+    dockerImage = "alisw/%s-builder" % args.architecture.split("_")[0]
+
   logger.setLevel(logging.BANNER)
   if args.debug:
     logger.setLevel(logging.DEBUG)
@@ -128,29 +147,36 @@ if __name__ == "__main__":
   packages = []
   exitcode = 0
   for p in args.packages:
-    path = "%s/%s.sh" % (args.config, p.lower())
+    path = "%s/%s.sh" % (args.configDir, p.lower())
     if not exists(path):
       error("Cannot find recipe %s for package %s." % (path, p))
       exitcode = 1
       continue
     packages.append(p)
-
   systemInfo()
 
   specs = {}
   def unreachable():
     assert(False)
+  defaultsReader = lambda : readDefaults(args.configDir, args.defaults, parser.error)
+  (err, overrides, taps) = parseDefaults(args.disable, defaultsReader, info)
+  if err:
+    error(err)
+    exit(1)
   (fromSystem, own, failed) = getPackageList(packages=packages,
                                          specs=specs,
-                                         configDir=args.config,
-                                         preferSystem=False,
-                                         noSystem=False,
+                                         configDir=args.configDir,
+                                         preferSystem=args.preferSystem,
+                                         noSystem=args.noSystem,
                                          architecture=args.architecture,
-                                         disable=[],
-                                         defaults="release",
+                                         disable=args.disable,
+                                         defaults=args.defaults,
                                          dieOnError=lambda x, y : unreachable,
-                                         performPreferCheck=lambda pkg, cmd : checkPreferSystem(pkg, cmd, homebrew_replacement),
-                                         performRequirementCheck=lambda pkg, cmd : checkRequirements(pkg, cmd, homebrew_replacement))
+                                         performPreferCheck=lambda pkg, cmd : checkPreferSystem(pkg, cmd, homebrew_replacement, dockerImage),
+                                         performRequirementCheck=lambda pkg, cmd : checkRequirements(pkg, cmd, homebrew_replacement, dockerImage),
+                                         overrides=overrides,
+                                         taps=taps,
+                                         log=info)
 
   if fromSystem:
     banner("The following packages will be picked up from the system:\n\n- " +

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -7,6 +7,19 @@ except ImportError:
 from os.path import dirname, exists
 import platform
 import base64
+from glob import glob
+from os.path import basename
+
+class SpecError(Exception):
+  pass
+
+def validateSpec(spec):
+  if not spec:
+    raise SpecError("Empty recipe.")
+  if type(spec) != dict:
+    raise SpecError("Not a YAML key / value.")
+  if not "package" in spec:
+    raise SpecError("Missing package field in header.")
 
 def format(s, **kwds):
   return s % kwds
@@ -89,8 +102,103 @@ def filterByArchitecture(arch, requires):
     if re.match(matcher, arch):
       yield require
 
+def readDefaults(configDir, defaults, error):
+  defaultsFilename = "%s/defaults-%s.sh" % (configDir, defaults)
+  if not exists(defaultsFilename):
+    viableDefaults = ["- " + basename(x).replace("defaults-","").replace(".sh", "")
+                      for x in glob("%s/defaults-*.sh" % configDir)]
+    error(format("Default `%(d)s' does not exists. Viable options:\n%(v)s",
+                 d=defaults or "<no defaults specified>",
+                 v="\n".join(viableDefaults)))
+  err, defaultsMeta, defaultsBody = parseRecipe(getRecipeReader(defaultsFilename))
+  if err:
+    error(err)
+    exit(1)
+  return (defaultsMeta, defaultsBody)
+
+# Get the appropriate recipe reader depending on th filename
+def getRecipeReader(url, dist=None):
+  m = re.search(r'^dist:(.*)@([^@]+)$', url)
+  if m and dist:
+    return GitReader(url, dist)
+  else:
+    return FileReader(url)
+
+# Read a recipe from a file
+class FileReader(object):
+  def __init__(self, url):
+    self.url = url
+  def __call__(self):
+    return open(self.url).read()
+
+# Read a recipe from a git repository using git show.
+class GitReader(object):
+  def __init__(self, url, configDir):
+    self.url, self.configDir = url, configDir
+  def __call__(self):
+    m = re.search(r'^dist:(.*)@([^@]+)$', self.url)
+    fn,gh = m.groups()
+    err,d = getstatusoutput(format("GIT_DIR=%(dist)s/.git git show %(gh)s:%(fn)s.sh",
+                                   dist=distdir, gh=gh, fn=fn.lower()))
+    if err:
+      raise RuntimeError(format("Cannot read recipe %(fn)s from reference %(gh)s.\n" +
+                                "Make sure you run first (this will not alter your recipes):\n" +
+                                "  cd %(dist)s && git remote update -p && git fetch --tags",
+                                dist=self.configDir, gh=gh, fn=fn))
+    warning("Overriding %s from reference %s" % (fn,gh))
+    return d
+
+def parseRecipe(reader):
+  assert(reader.__call__)
+  try:
+    d = reader()
+    err, spec, recipe = (None, None, None)
+    header,recipe = d.split("---", 1)
+    spec = yaml.safe_load(header)
+    validateSpec(spec)
+  except RuntimeError as e:
+    err = str(e)
+  except IOError as e:
+    err = str(e)
+  except SpecError, e:
+    err = "Malformed header for %s\n%s" % (reader.url, str(e))
+  except yaml.scanner.ScannerError, e:
+    err = "Unable to parse %s\n%s" % (reader.url, str(e))
+  except yaml.parser.ParserError, e:
+    err = "Unable to parse %s\n%s" % (reader.url, str(e))
+  except ValueError, e:
+    err = "Unable to parse %s. Header missing." % reader.url
+  return err, spec, recipe
+
+# (Almost pure part of the defaults parsing)
+# Override defaultsGetter for unit tests.
+def parseDefaults(disable, defaultsGetter, log):
+  defaultsMeta, defaultsBody = defaultsGetter()
+  # Defaults are actually special packages. They can override metadata
+  # of any other package and they can disable other packages. For
+  # example they could decide to switch from ROOT 5 to ROOT 6 and they
+  # could disable alien for O2. For this reason we need to parse their
+  # metadata early and extract the override and disable data.
+  defaultsDisable = defaultsMeta.get("disable", [])
+  if type(defaultsDisable) == str:
+    defaultsDisable = [defaultsDisable]
+  for x in defaultsDisable:
+    log("Package %s has been disabled by current default." % x)
+  disable.extend(defaultsDisable)
+  if type(defaultsMeta.get("overrides", {})) != dict:
+    return ("overrides should be a dictionary", None, None)
+  overrides = {}
+  taps = {}
+  for k, v in defaultsMeta.get("overrides", {}).items():
+    f = k.split("@", 1)[0].lower()
+    if "@" in k:
+      taps[f] = "dist:"+k
+    overrides[f] = v
+  return (None, overrides, taps)
+
 def getPackageList(packages, specs, configDir, preferSystem, noSystem,
-                   architecture, disable, defaults, dieOnError, performPreferCheck, performRequirementCheck):
+                   architecture, disable, defaults, dieOnError, performPreferCheck, performRequirementCheck,
+                   overrides, taps, log):
   systemPackages = set()
   ownPackages = set()
   failedRequirements = set()
@@ -100,19 +208,23 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
     p = packages.pop(0)
     if p in specs:
       continue
-    try:
-      d = open("%s/%s.sh" % (configDir, p.lower())).read()
-    except IOError as e:
-      dieOnError(True, str(e))
-    header, recipe = d.split("---", 1)
-    spec = yaml.safe_load(header)
-    dieOnError(spec["package"].lower() != p.lower(),
+    lowerPkg = p.lower()
+    filename = taps.get(lowerPkg, "%s/%s.sh" % (configDir, lowerPkg))
+    err, spec, recipe = parseRecipe(getRecipeReader(filename, configDir))
+    dieOnError(err, err)
+    dieOnError(spec["package"].lower() != lowerPkg,
                "%s.sh has different package field: %s" % (p, spec["package"]))
+
+    # If the package has overrides, we apply them.
+    if lowerPkg in overrides:
+      log("Overrides for package %s: %s" % (spec["package"], overrides[lowerPkg]))
+      spec.update(overrides.get(lowerPkg, {}) or {})
+
     # If --always-prefer-system is passed or if prefer_system is set to true
     # inside the recipe, use the script specified in the prefer_system_check
     # stanza to see if we can use the system version of the package.
     if not noSystem and (preferSystem or re.match(spec.get("prefer_system", "(?!.*)"), architecture)):
-      cmd = spec.get("prefer_system_check", "false")
+      cmd = spec.get("prefer_system_check", "false").strip()
       if not spec["package"] in testCache:
         testCache[spec["package"]] = performPreferCheck(spec, cmd.strip())
 
@@ -150,7 +262,7 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
     spec["runtime_requires"] = spec["requires"]
     spec["requires"] = spec["runtime_requires"] + spec["build_requires"]
     # Check that version is a string
-    dieOnError(not isinstance(spec["version"], basestring),
+    dieOnError(not isinstance(spec["version"], str),
                "In recipe \"%s\": version must be a string" % p)
     spec["tag"] = spec.get("tag", spec["version"])
     spec["version"] = spec["version"].replace("/", "_")
@@ -159,10 +271,10 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
     packages += spec["requires"]
   return (systemPackages, ownPackages, failedRequirements)
 
-def dockerStatusOutput(cmd, dockerImage=None):
+def dockerStatusOutput(cmd, dockerImage=None, executor=getstatusoutput):
   if dockerImage:
     DOCKER_WRAPPER = """docker run %(di)s bash -c 'eval "$(echo %(c)s | base64 --decode)"'"""
     cmd = format(DOCKER_WRAPPER,
                  di=dockerImage,
                  c=base64.b64encode(cmd))
-  return getstatusoutput(cmd)
+  return executor(cmd)

--- a/tests/test_parseRecipe.py
+++ b/tests/test_parseRecipe.py
@@ -1,0 +1,109 @@
+import unittest
+import platform
+from alibuild_helpers.utilities import parseRecipe, getRecipeReader, parseDefaults
+from alibuild_helpers.utilities import FileReader, GitReader
+
+TEST1="""package: foo
+version: bar
+---
+"""
+
+TEST_BROKEN_1 = "broken"
+TEST_BROKEN_2 = "---"
+TEST_BROKEN_3 = """gfooo:
+   - :
+---
+"""
+TEST_BROKEN_4 = """broken
+---
+"""
+
+TEST_BROKEN_5 = """tag: foo
+---
+"""
+
+TEST_BROKEN_6 = """tag: "foo
+---
+"""
+
+ERROR_MSG_3 ="""Unable to parse test_broken_3.sh
+while parsing a block mapping
+expected <block end>, but found ':'
+  in "<string>", line 2, column 6:
+       - :
+         ^"""
+
+ERROR_MSG_4 = """Malformed header for test_broken_4.sh
+Not a YAML key / value."""
+
+ERROR_MSG_5 = """Malformed header for test_broken_5.sh
+Missing package field in header."""
+
+ERROR_MSG_6 = """Unable to parse test_broken_6.sh
+while scanning a quoted scalar
+  in "<string>", line 1, column 6:
+    tag: "foo
+         ^
+found unexpected end of stream
+  in "<string>", line 2, column 1:
+    
+    ^"""
+
+class Recoder(object):
+  def __init__(self):
+    self.buffer = ""
+  def __call__(self, s):
+    self.buffer += s
+
+class BufferReader(object):
+  def __init__(self, filename, recipe):
+    self.url = filename
+    self.buffer = recipe
+  def __call__(self):
+    return self.buffer
+
+class TestRecipes(unittest.TestCase):
+  def test_recipes(self):
+    err, meta, body = parseRecipe(BufferReader("test1.sh", TEST1))
+    assert(err == None)
+    assert(meta["package"] == "foo")
+    assert(meta["version"] == "bar")
+    err, meta, body = parseRecipe(BufferReader("test_broken_1.sh", TEST_BROKEN_1))
+    assert(err == "Unable to parse test_broken_1.sh. Header missing.")
+    err, meta, body = parseRecipe(BufferReader("test_broken_2.sh", TEST_BROKEN_2))
+    assert(err == "Malformed header for test_broken_2.sh\nEmpty recipe.")
+    assert(not meta and not body)
+    err, meta, body = parseRecipe(BufferReader("test_broken_3.sh", TEST_BROKEN_3))
+    assert(err == ERROR_MSG_3)
+    assert(meta == None)
+    assert(body.strip() == "")
+    err, meta, body = parseRecipe(BufferReader("test_broken_4.sh", TEST_BROKEN_4))
+    assert(err == ERROR_MSG_4)
+    err, meta, body = parseRecipe(BufferReader("test_broken_5.sh", TEST_BROKEN_5))
+    assert(err == ERROR_MSG_5)
+    err, meta, body = parseRecipe(BufferReader("test_broken_6.sh", TEST_BROKEN_6))
+    assert(err.strip() == ERROR_MSG_6.strip())
+
+  def test_getRecipeReader(self):
+    f = getRecipeReader("foo")
+    assert(type(f) == FileReader)
+    f = getRecipeReader("dist:foo@master")
+    assert(type(f) == FileReader)
+    f = getRecipeReader("dist:foo@master", "alidist")
+    assert(type(f) == GitReader)
+
+  def test_parseDefaults(self):
+    disable = ["bar"]
+    err, overrides, taps = parseDefaults(disable,
+                                        lambda : ({"disable": "foo",
+                                                   "overrides": {"ROOT@master": {"requires": "GCC"}}}, ""),
+                                        Recoder())
+    assert(disable == ["bar", "foo"])
+    assert(overrides == {'root': {'requires': 'GCC'}})
+    assert(taps == {'root': 'dist:ROOT@master'})
+    print err, overrides, taps
+    print disable
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
By using the same set of functions, aliBuild and aliDoctor should now
behave exactly the same. It's also now possible to pass --disable and
--defaults to aliDoctor and get the diagnosis for the chosen setup. By
factoring out the IO related code, this should also improve our ability
to unit test things.