### PR TITLE
Fix aliBuild clean

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -507,9 +507,12 @@ def doMain():
     toDelete += [x for x in glob("%s/BUILD/*" % args.workDir)
                  if not islink(x) and not basename(x) in symlinksBuild]
     installGlob ="%s/%s/*/" % (args.workDir, args.architecture)
-    symlinksInstall = [readlink(x) for x in glob(installGlob + "latest*")]
+    installedPackages = set([dirname(x) for x in glob(installGlob)])
+    symlinksInstall = []
+    for x in installedPackages:
+      symlinksInstall += [realpath(y) for y in glob(x + "/latest*")]
     toDelete += [x for x in glob(installGlob+ "*")
-                 if not islink(x) and not basename(x) in symlinksInstall]
+                 if not islink(x) and not realpath(x) in symlinksInstall]
     toDelete = [x for x in toDelete if exists(x)]
     if not toDelete:
       print("Nothing to delete.")


### PR DESCRIPTION
Given a package aliBuild did not delete a given version, e.g. v1.0, if a
symlink called latest* existed in any package, not only in the one being
looked at. This caused a few packages not being deleted.

This resolves the issue by making sure that the `latest` link is
actually in the same directory.