### PR TITLE
Disable write store only at first devel package

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -657,8 +657,6 @@ def doMain():
                   "In most cases this is achieved by doing in the package source directory:\n\n"
                   "  git pull --rebase\n",
                   pwd=os.getcwd(), star=star()))
-    debug("Write store disabled since some packages will be picked up from local checkout.")
-    syncHelper.writeStore = ""
 
   # Resolve the tag to the actual commit ref, so that
   for p in buildOrder:
@@ -854,6 +852,10 @@ def doMain():
       exit(1)
     p = buildOrder[0]
     spec = specs[p]
+    if spec["package"] in develPkgs and getattr(syncHelper, "writeStore", None):
+      warning("Disabling remote write store from now since %s is a development package." % spec["package"])
+      syncHelper.writeStore = ""
+
     # Since we can execute this multiple times for a given package, in order to
     # ensure consistency, we need to reset things and make them pristine.
     spec.pop("revision", None)


### PR DESCRIPTION
Previously write store was disabled in case a development package was
found in the dependency tree. This changes the behavior to be less
aggressive and disables the ability to write to the store only once the
first development package is encountered while building.