### PR TITLE
Disable write store only at first devel package

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -21,6 +21,7 @@ from alibuild_helpers.log import logger_handler, logger, LogFormatter, ProgressP
 from alibuild_helpers.utilities import format, getVersion, detectArch, dockerStatusOutput, parseDefaults, readDefaults
 from alibuild_helpers.utilities import parseRecipe, getPackageList, getRecipeReader
 from alibuild_helpers.utilities import Hasher
+from alibuild_helpers.utilities import validateDefaults
 from alibuild_helpers.analytics import decideAnalytics, askForAnalytics, report_screenview, report_exception, report_event
 from alibuild_helpers.analytics import enable_analytics, disable_analytics
 import traceback
@@ -657,6 +658,13 @@ def doMain():
                   "In most cases this is achieved by doing in the package source directory:\n\n"
                   "  git pull --rebase\n",
                   pwd=os.getcwd(), star=star()))
+
+  # Determine if the default is ok for the given package
+  finalPkgSpec = specs[buildOrder[-1]]
+  ok, out = validateDefaults(finalPkgSpec, args.defaults)
+  if not ok:
+    error(out)
+    exit(1)
 
   # Resolve the tag to the actual commit ref, so that
   for p in buildOrder:

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -22,6 +22,23 @@ def validateSpec(spec):
   if not "package" in spec:
     raise SpecError("Missing package field in header.")
 
+# Use this to check if a given spec is compatible with the given default
+def validateDefaults(finalPkgSpec, defaults):
+  if not "valid_defaults" in finalPkgSpec:
+    return (True, "")
+  validDefaults = finalPkgSpec["valid_defaults"]
+  if not type(validDefaults) == list:
+    validDefaults = [validDefaults]
+  nonStringDefaults = [x for x in validDefaults if not type(x) == str]
+  if nonStringDefaults:
+    return (False, "valid_defaults needs to be a string or a list of strings. Found %s." % nonStringDefaults)
+  if defaults in validDefaults:
+    return (True, "")
+  return (False, "Cannot compile %s with `%s' default. Valid defaults are\n%s" % 
+                  (finalPkgSpec["package"],
+                   defaults,
+                   "\n".join([" - " + x for x in validDefaults])))
+
 def format(s, **kwds):
   if type(s) == bytes:
     s = s.decode()

--- a/tests/test_parseRecipe.py
+++ b/tests/test_parseRecipe.py
@@ -2,6 +2,7 @@ import unittest
 import platform
 from alibuild_helpers.utilities import parseRecipe, getRecipeReader, parseDefaults
 from alibuild_helpers.utilities import FileReader, GitReader
+from alibuild_helpers.utilities import validateDefaults, SpecError
 
 TEST1="""package: foo
 version: bar
@@ -103,6 +104,25 @@ class TestRecipes(unittest.TestCase):
     assert(taps == {'root': 'dist:ROOT@master'})
     print err, overrides, taps
     print disable
+
+  def test_validateDefault(self):
+    ok, valid = validateDefaults({"something": True}, "release")
+    self.assertEqual(ok, True)
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": ["o2", "o2-daq"]}, "release")
+    self.assertEqual(ok, False)
+    self.assertEqual(valid, 'Cannot compile foo with release default. Valid defaults are\no2\no2-daq')
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": ["o2", "o2-daq"]}, "o2")
+    self.assertEqual(ok, True)
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": "o2-daq"}, "o2")
+    self.assertEqual(ok, False)
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": "o2"}, "o2")
+    self.assertEqual(ok, True)
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": 1}, "o2")
+    self.assertEqual(ok, False)
+    self.assertEqual(valid, 'valid_defaults needs to be a string or a list of strings. Found [1].')
+    ok, valid = validateDefaults({"package": "foo", "valid_defaults": {}}, "o2")
+    self.assertEqual(ok, False)
+    self.assertEqual(valid, 'valid_defaults needs to be a string or a list of strings. Found [{}].')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously write store was disabled in case a development package was
found in the dependency tree. This changes the behavior to be less
aggressive and disables the ability to write to the store only once the
first development package is encountered while building.