### PR TITLE
Introduce valid_defaults metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,8 @@ script: |
   time coverage run -a alibuild/aliBuild -c alibuild/tests/testdist build broken4 --no-system --disable GCC-Toolchain 2>&1 | grep "Malformed header"
   time coverage run -a alibuild/aliBuild -c alibuild/tests/testdist build broken5 --no-system --disable GCC-Toolchain 2>&1 | grep "Missing package"
   time coverage run -a alibuild/aliBuild -c alibuild/tests/testdist build broken6 --no-system --disable GCC-Toolchain 2>&1 | grep scanning
-  pushd alibuild
-    time coverage run -a tests/test_parseRecipe.py
-    time coverage run -a tests/test_utilities.py
-  popd
+  PYTHONPATH=alibuild time coverage run -a alibuild/tests/test_parseRecipe.py
+  PYTHONPATH=alibuild time coverage run -a alibuild/tests/test_utilities.py
   time coverage run -a alibuild/aliBuild build zlib --no-system --disable GCC-Toolchain
   alibuild/alienv q
   alibuild/alienv setenv zlib/latest -c bash -c '[[ $LD_LIBRARY_PATH == */zlib/* ]]'

--- a/aliBuild
+++ b/aliBuild
@@ -21,6 +21,7 @@ from alibuild_helpers.log import logger_handler, logger, LogFormatter, ProgressP
 from alibuild_helpers.utilities import format, getVersion, detectArch, dockerStatusOutput, parseDefaults, readDefaults
 from alibuild_helpers.utilities import parseRecipe, getPackageList, getRecipeReader
 from alibuild_helpers.utilities import Hasher
+from alibuild_helpers.utilities import validateDefaults
 from alibuild_helpers.analytics import decideAnalytics, askForAnalytics, report_screenview, report_exception, report_event
 from alibuild_helpers.analytics import enable_analytics, disable_analytics
 import traceback
@@ -658,6 +659,7 @@ def doMain():
                   "  git pull --rebase\n",
                   pwd=os.getcwd(), star=star()))
 
+
   # Resolve the tag to the actual commit ref, so that
   for p in buildOrder:
     spec = specs[p]
@@ -746,11 +748,16 @@ def doMain():
                      (mainPackage, args.develPrefix if "develPrefix" in args else mainHash[0:8])))
 
   # Now that we have the main package set, we can print out Useful information
-  # which we will be able to associate with this build.
+  # which we will be able to associate with this build. Also lets make sure each package
+  # we need to build can be built with the current default.
   for p in buildOrder:
     spec = specs[p]
     if "source" in spec:
       debug("Commit hash for %s@%s is %s" % (spec["source"], spec["tag"], spec["commit_hash"]))
+    ok, out = validateDefaults(spec, args.defaults)
+    if not ok:
+      error(out)
+      exit(1)
 
   # Calculate the hashes. We do this in build order so that we can guarantee
   # that the hashes of the dependencies are calculated first.  Also notice that

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -22,6 +22,23 @@ def validateSpec(spec):
   if not "package" in spec:
     raise SpecError("Missing package field in header.")
 
+# Use this to check if a given spec is compatible with the given default
+def validateDefaults(finalPkgSpec, defaults):
+  if not "valid_defaults" in finalPkgSpec:
+    return (True, "")
+  validDefaults = finalPkgSpec["valid_defaults"]
+  if not type(validDefaults) == list:
+    validDefaults = [validDefaults]
+  nonStringDefaults = [x for x in validDefaults if not type(x) == str]
+  if nonStringDefaults:
+    return (False, "valid_defaults needs to be a string or a list of strings. Found %s." % nonStringDefaults)
+  if defaults in validDefaults:
+    return (True, "")
+  return (False, "Cannot compile %s with `%s' default. Valid defaults are\n%s" % 
+                  (finalPkgSpec["package"],
+                   defaults,
+                   "\n".join([" - " + x for x in validDefaults])))
+
 def format(s, **kwds):
   if type(s) == bytes:
     s = s.decode()

--- a/tests/test_parseRecipe.py
+++ b/tests/test_parseRecipe.py
@@ -2,6 +2,7 @@ import unittest
 import platform
 from alibuild_helpers.utilities import parseRecipe, getRecipeReader, parseDefaults
 from alibuild_helpers.utilities import FileReader, GitReader
+from alibuild_helpers.utilities import validateDefaults, SpecError
 
 TEST1="""package: foo
 version: bar
@@ -103,6 +104,25 @@ class TestRecipes(unittest.TestCase):
     assert(taps == {'root': 'dist:ROOT@master'})
     print err, overrides, taps
     print disable
+
+  def test_validateDefault(self):
+    ok, valid = validateDefaults({"something": True}, "release")
+    self.assertEqual(ok, True)
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": ["o2", "o2-daq"]}, "release")
+    self.assertEqual(ok, False)
+    self.assertEqual(valid, 'Cannot compile foo with `release\' default. Valid defaults are\n - o2\n - o2-daq')
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": ["o2", "o2-daq"]}, "o2")
+    self.assertEqual(ok, True)
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": "o2-daq"}, "o2")
+    self.assertEqual(ok, False)
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": "o2"}, "o2")
+    self.assertEqual(ok, True)
+    ok, valid = validateDefaults({"package": "foo","valid_defaults": 1}, "o2")
+    self.assertEqual(ok, False)
+    self.assertEqual(valid, 'valid_defaults needs to be a string or a list of strings. Found [1].')
+    ok, valid = validateDefaults({"package": "foo", "valid_defaults": {}}, "o2")
+    self.assertEqual(ok, False)
+    self.assertEqual(valid, 'valid_defaults needs to be a string or a list of strings. Found [{}].')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Some packages can only be compiled using a given default. Most notably,
the O2 package can only be built with `--defaults o2` or `--defaults
o2-daq`. It's now possible to express that by adding a valid_defaults
entry in the YAML preable which contains the list of valid defaults.