### PR TITLE
Apply defaults only to overriden packages

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -651,7 +651,7 @@ def doMain():
 
   if buildOrder:
     banner("Packages will be built in the following order:\n - %s" %
-           "\n - ".join([ x+" (development package)" if x in develPkgs else "%s@%s" % (x, specs[x]["tag"]) for x in buildOrder ]))
+           "\n - ".join([ x+" (development package)" if x in develPkgs else "%s@%s" % (x, specs[x]["tag"]) for x in buildOrder if x != "defaults-release" ]))
 
   if develPkgs:
     banner(format("You have packages in development mode.\n"

--- a/tests/test_parseRecipe.py
+++ b/tests/test_parseRecipe.py
@@ -100,10 +100,8 @@ class TestRecipes(unittest.TestCase):
                                                    "overrides": {"ROOT@master": {"requires": "GCC"}}}, ""),
                                         Recoder())
     assert(disable == ["bar", "foo"])
-    assert(overrides == {'root': {'requires': 'GCC'}})
+    assert(overrides == {'defaults-release': {}, 'root': {'requires': 'GCC'}})
     assert(taps == {'root': 'dist:ROOT@master'})
-    print err, overrides, taps
-    print disable
 
   def test_validateDefault(self):
     ok, valid = validateDefaults({"something": True}, "release")


### PR DESCRIPTION
Before this patch, different defaults were effectively generating
different packages. This makes sure that only the bits which have
been overridden trigger a rebuild of the overriden package and its
dependencies, but not more.
