### PR TITLE
Replace non-ascii in logger

### DIFF
--- a/alibuild_helpers/log.py
+++ b/alibuild_helpers/log.py
@@ -69,6 +69,8 @@ class LogFormatter(logging.Formatter):
                           logging.CRITICAL: "\033[1;37;41m",
                           logging.SUCCESS:  "\033[1;32m" } if sys.stdout.isatty() else {}
   def format(self, record):
+    # Replace all non-ascii characters as they aren't properly handled
+    record.msg = record.msg.encode('ascii','replace')
     if record.levelno == logging.BANNER and sys.stdout.isatty():
       lines = str(record.msg).split("\n")
       return "\n\033[1;34m==>\033[m \033[1m%s\033[m" % lines[0] + \


### PR DESCRIPTION
Building O2 with aliBuild I get an exception in aliBuild. The problem is the unicode character 2026, the horizontal ellipsis, i.e. three dots as one character. Following https://docs.python.org/2/howto/unicode.html I replace all non-ascii characters in the logger.

```
== old == 
DEBUG:O2:O2-master: -- Looking for ZeroMQ...
DEBUG:O2:O2-master: -- Looking for ZeroMQ... - found /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/ZeroMQ/v4.1.5-1/lib/libzmq.a;/home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/ZeroMQ/v4.1.5-1/lib/libzmq.so 4.1.5
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/home/hbeck/.local/lib/python2.7/site-packages/alibuild_helpers/log.py", line 83, in format
    for x in str(record.msg).split("\n") ])
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2026' in position 31: ordinal not in range(128)
Logged from file aliBuild, line 52
DEBUG:O2:O2-master: -- FairRoot ... - found /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/FairRoot/dev-2
DEBUG:O2:O2-master: -- FairRoot Library directory  :     /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/FairRoot/dev-2/lib
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 861, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 734, in format
    return fmt.format(record)
  File "/home/hbeck/.local/lib/python2.7/site-packages/alibuild_helpers/log.py", line 83, in format
    for x in str(record.msg).split("\n") ])
UnicodeEncodeError: 'ascii' codec can't encode character u'\u2026' in position 24: ordinal not in range(128)
Logged from file aliBuild, line 52
DEBUG:O2:O2-master: -- FairRoot Cmake Modules      :     /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/FairRoot/dev-2/share/fairbase/cmake
DEBUG:O2:O2-master: -- FairRoot ... - found /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/FairRoot/dev-2
```

```
== new ===
DEBUG:O2:O2-master: -- Looking for ZeroMQ...
DEBUG:O2:O2-master: -- Looking for ZeroMQ... - found /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/ZeroMQ/v4.1.5-1/lib/libzmq.a;/home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/ZeroMQ/v4.1.5-1/lib/libzmq.so 4.1.5
DEBUG:O2:O2-master: -- Setting FairRoot environment?
DEBUG:O2:O2-master: -- FairRoot ... - found /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/FairRoot/dev-2
DEBUG:O2:O2-master: -- FairRoot Library directory  :     /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/FairRoot/dev-2/lib
DEBUG:O2:O2-master: -- FairRoot Include path?      :     /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/FairRoot/dev-2/include
DEBUG:O2:O2-master: -- FairRoot Cmake Modules      :     /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/FairRoot/dev-2/share/fairbase/cmake
DEBUG:O2:O2-master: -- FairRoot ... - found /home/hbeck/alice/alibuild/sw/ubuntu1604_x86-64/FairRoot/dev-2
```