### PR TITLE
Add defaults name to message when build ends

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -1302,10 +1302,11 @@ def doMain():
               "Your software installation is at:"
               "\n\n  %(wp)s\n\n"
               "You can use this package by loading the environment:"
-              "\n\n  alienv enter %(mainPackage)s/%(pkgVer)s",
+              "\n\n  alienv enter %(mainPackage)s/%(pkgVer)s-%(defaults)s",
               mainPackage=mainPackage,
               h=socket.gethostname(),
               pkgVer="latest-"+args.develPrefix if mainPackage in develPkgs and "develPrefix" in args else "latest",
+              defaults=args.defaults,
               wp=abspath(join(args.workDir, args.architecture))))
   for x in develPkgs:
     banner(format("Build directory for devel package %(p)s:\n%(w)s/BUILD/%(p)s-latest%(devSuffix)s/%(p)s",


### PR DESCRIPTION
The old message suggested the user to use `alienv enter` with a non-existing package.