### PR TITLE
improve osx relocation of dynamically linked binaries

### DIFF
--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -168,14 +168,40 @@ cat "$INSTALLROOT/.original-unrelocated" | xargs -n1 -I{} echo "sed -e \"s|/[^ ]
 if [[ ! -s "$INSTALLROOT/.original-unrelocated" && -f "$INSTALLROOT/etc/modulefiles/$PKGNAME" ]]; then
   echo "mv -f \$PP/etc/modulefiles/$PKGNAME \$PP/etc/modulefiles/${PKGNAME}.forced-relocation && sed -e \"s|[@][@]PKGREVISION[@]\$PH[@][@]|$PKGREVISION|g\" \$PP/etc/modulefiles/${PKGNAME}.forced-relocation > \$PP/etc/modulefiles/$PKGNAME" >> "$INSTALLROOT/relocate-me.sh"
 fi
-# Find libraries needing relocation on macOS
-if [[ ${ARCHITECTURE:0:3} == osx ]]; then
-  find . -name '*.dylib' -o -name '*.so' | \
-    xargs -n1 -I{} sh -c "otool -D {}|tail -n1|grep -q $PKGHASH && echo {} | sed -e 's|^\.|\$PP|'" | \
-      while read LIB; do
-        echo "install_name_tool -id \`otool -D \"$LIB\"|tail -n1|sed -e \"s|/[^ ]*INSTALLROOT/\$PH/\$OP|\$WORK_DIR/\$PP|g\"\` \"$LIB\"" >> "$INSTALLROOT/relocate-me.sh"
-      done || true
+
+# Find libraries and executables needing relocation on macOS
+if [[ ${ARCHITECTURE:0:3} == "osx" ]]; then
+  find . -type f | xargs -n1 -P${JOBS:-4} file | grep -e 'Mach-O.*executable' -e 'Mach-O.*dynamically linked shared library' | cut -d':' -f1 | sed -e 's/^\.\///' | \
+  while read BIN; do
+    # Relocate LC_ID_DYLIB
+    if { file "$BIN" | grep 'Mach-O.*dynamically linked shared library' | cut -d':' -f1 | xargs -n1 otool -D | tail -n1 | grep -q $PKGHASH; }; then
+cat << EOF >> "$INSTALLROOT/relocate-me.sh"
+install_name_tool -id \$(otool -D "\$PP/$BIN" | tail -n1 | sed -e "s|/[^ ]*INSTALLROOT/\$PH/\$OP|\$WORK_DIR/\$PP|g") "\$PP/$BIN"
+EOF
+    fi
+    # Relocate LC_RPATH
+    if { otool -l "$BIN" | grep -A2 LC_RPATH | grep path | grep -q $PKGHASH; }; then
+cat << EOF >> "$INSTALLROOT/relocate-me.sh"
+OLD_RPATHS=\$(otool -l \$PP/$BIN | grep -A2 LC_RPATH | grep path | grep \$PH | sed -e 's|^.*path ||' -e 's| .*$||')
+for OLD_RPATH in \$OLD_RPATHS; do
+  NEW_RPATH=\${OLD_RPATH/#*INSTALLROOT\/\$PH\/\$OP/\$WORK_DIR/\$PP}
+  install_name_tool -rpath "\$OLD_RPATH" "\$NEW_RPATH" "\$PP/$BIN"
+done
+EOF
+    fi
+    # Relocate LC_LOAD_DYLIB
+    if { otool -l "$BIN" | grep -A2 LC_LOAD_DYLIB | grep name | grep -q $PKGHASH; }; then
+cat << EOF >> "$INSTALLROOT/relocate-me.sh"
+OLD_LOAD_DYLIBS=\$(otool -l \$PP/$BIN | grep -A2 LC_LOAD_DYLIB | grep name | grep \$PH | sed -e 's|^.*name ||' -e 's| .*$||')
+for OLD_LOAD_DYLIB in \$OLD_LOAD_DYLIBS; do
+  NEW_LOAD_DYLIB=\${OLD_LOAD_DYLIB/#*INSTALLROOT\/\$PH\/\$OP/\$WORK_DIR/\$PP}
+  install_name_tool -change "\$OLD_LOAD_DYLIB" "\$NEW_LOAD_DYLIB" "\$PP/$BIN"
+done
+EOF
+    fi
+  done || true
 fi
+
 cat "$INSTALLROOT/relocate-me.sh"
 cat "$INSTALLROOT/.original-unrelocated" | xargs -n1 -I{} cp '{}' '{}'.unrelocated
 cd "$WORK_DIR/INSTALLROOT/$PKGHASH"


### PR DESCRIPTION
 * search all directories
 * relocate `LC_ID_DYLIB`, `LC_RPATH` and `LC_LOAD_DYLIB` entries
 * relocate dylibs and executables

Co-authored-by: Dario Berzano <dario.berzano@cern.ch>
Co-authored-by: Florian Uhlig <f.uhlig@gsi.de>

---

This is part of the resolution of AliceO2Group/AliceO2#343. Moreover, this is based on the work done by @dberzano (#387) and @fuhlig1 (#420) - please read those discussions for context.

@dberzano 's change that invalidates existing builds, I have left out, because @ktf has reverted it in the `dev` branch, but I don't know the reason yet.

I did not implement my proposal about enforcing "`@rpath`iazation" that I have mentioned in the discussion in #420. After another discussion with @fuhlig1 he convinced me, that this should be an upstream decision.

The serial `find + file` variant takes several minutes on spinning disks and large packages like ROOT, that is why I chose a parallel variant.

The generated code could be more elegant, e.g. a variable with all the files and just one loop for each relocation type. But I found for debugging it is quite nice to have the code for single files in a copy&pastable format.

Please test! I only have one mac version `10.11.6` to test. You can inspect the resulting dylibs and executables with `otool -l`.