### PR TITLE
Allow non /bin/bash file location for bash

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -77,6 +77,8 @@ version: v1
 """
 
 def dummy_getstatusoutput(x):
+  if re.match("/bin/bash --version", x):
+    return (0, "GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin17)\nCopyright (C) 2007 Free Software Foundation, Inc.\n")
   if re.match("mkdir -p [^;]*$", x):
     return (0, "")
   if re.match("ln -snf[^;]*$", x):


### PR DESCRIPTION
In case /bin/bash is present we keep honouring using it for backward
compatibility. In case it's not, we fall back to whatever bash is in
path.