### PR TITLE
Fix dylib relocation and support System Integrity Protection

### DIFF
--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -183,6 +183,10 @@ if [[ ${ARCHITECTURE:0:3} == "osx" ]]; then
         cat <<EOF >> "$INSTALLROOT/relocate-me.sh"
 install_name_tool -id \$(otool -D "\$PP/$BIN" | tail -n1 | sed -e "s|/[^ ]*INSTALLROOT/\$PH/\$OP|\$WORK_DIR/\$PP|g") "\$PP/$BIN"
 EOF
+      elif otool -D "$PWD/$BIN" 2> /dev/null | tail -n1 | grep -vq /; then
+        cat <<EOF >> "$INSTALLROOT/relocate-me.sh"
+install_name_tool -id "\$WORK_DIR/\$PP/$BIN" "\$PP/$BIN"
+EOF
       fi
     fi
 


### PR DESCRIPTION
Hi,
This commit fixes the leak of dylib relocations.

Previously fastjet build was failed with SIP due to the cgal dylibs are not correctly relocated.
Some dylibs which install_name only contain basename (no / in its name!) part are fixed to have abs path.
After this change, fastjet should build successfully.