### PR TITLE
Only clone reference repos by default, fetch updates with --fetch-repos or -u

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -75,9 +75,7 @@ def doMain(args, parser):
 
   # Setup build environment.
   if args.action == "init":
-    doInit(setdir=args.develPrefix, configDir=args.configDir,
-           pkgname=args.pkgname, referenceSources=args.referenceSources,
-           dist=args.dist, defaults=args.defaults, dryRun=args.dryRun)
+    doInit(args)
     exit(0)
 
   if args.action == "build":

--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -171,7 +171,7 @@ def doParseArgs(star):
   return (args, parser)
 
 VALID_ARCHS_RE = ["slc[5-9]+_(x86-64|ppc64)",
-                  "(ubuntu|ubt|osx)[0-9]*_x86-64",
+                  "(ubuntu|ubt|osx|fedora)[0-9]*_x86-64",
                  ]
 
 def matchValidArch(architecture):
@@ -185,7 +185,9 @@ ARCHITECTURE_TABLE = [
            "   Ubuntu 14.04 compatible: ubuntu1404_x86-64\n"
            "   Ubuntu 15.04 compatible: ubuntu1504_x86-64\n"
            "   Ubuntu 15.10 compatible: ubuntu1510_x86-64\n"
-           "   Ubuntu 16.04 compatible: ubuntu1604_x86-64\n\n"
+           "   Ubuntu 16.04 compatible: ubuntu1604_x86-64\n"
+           "   Fedora 25 compatible: fedora25_x86-64\n"
+           "   Fedora 26 compatible: fedora26_x86-64\n\n"
            "On Linux, POWER8 / PPC64 (little endian):\n"
            "   RHEL7 / CC7 compatible: slc7_ppc64\n\n"
            "On Mac, x86-64:\n"

--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -108,6 +108,8 @@ def doParseArgs(star):
                       dest="autoCleanup", action="store_false", default=True)
   build_parser.add_argument("--devel-prefix", "-z", nargs="?", help="Version name to use for development packages. Defaults to branch name.",
                       dest="develPrefix", default=argparse.SUPPRESS)
+  build_parser.add_argument("--fetch-repos", "-u", dest="fetchRepos", default=False,
+                            action="store_true", help="Fetch repository updates")
 
   group = build_parser.add_mutually_exclusive_group()
   group.add_argument("--always-prefer-system", dest="preferSystem", default=False,
@@ -151,6 +153,8 @@ def doParseArgs(star):
                             metavar="FILE", help="Specify which defaults to use")
   init_parser.add_argument("--chdir", "-C", help="Change to the specified directory first",
                            metavar="DIR", dest="chdir", default=DEFAULT_CHDIR)
+  init_parser.add_argument("--fetch-repos", "-u", dest="fetchRepos", default=False,
+                           action="store_true", help="Fetch repository updates")
 
   # Options for the version subcommand
   version_parser.add_argument("--architecture", "-a", dest="architecture",

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -5,7 +5,7 @@ from alibuild_helpers.log import debug, error, warning, banner, info
 from alibuild_helpers.log import dieOnError
 from alibuild_helpers.workarea import updateReferenceRepos
 
-from os.path import basename, join
+from os.path import abspath, basename, join
 import os.path as path
 import os
 try:
@@ -17,31 +17,31 @@ def parsePackagesDefinition(pkgname):
   return [ dict(zip(["name","ver"], y.split("@")[0:2]))
            for y in [ x+"@" for x in list(filter(lambda y: y, pkgname.split(","))) ] ]
 
-def doInit(setdir, configDir, pkgname, referenceSources, dist, defaults, dryRun):
-  assert(pkgname != None)
-  assert(type(dist) == dict)
-  assert(sorted(dist.keys()) == ["repo", "ver"])
-  pkgs = parsePackagesDefinition(pkgname)
+def doInit(args):
+  assert(args.pkgname != None)
+  assert(type(args.dist) == dict)
+  assert(sorted(args.dist.keys()) == ["repo", "ver"])
+  pkgs = parsePackagesDefinition(args.pkgname)
   assert(type(pkgs) == list)
-  if dryRun:
+  if args.dryRun:
     info("This will initialise local checkouts for %s\n"
          "--dry-run / -n specified. Doing nothing." % ",".join(x["name"] for x in pkgs))
     exit(0)
   try:
-    path.exists(setdir) or os.mkdir(setdir)
-    path.exists(referenceSources) or os.makedirs(referenceSources)
+    path.exists(args.develPrefix) or os.mkdir(args.develPrefix)
+    path.exists(args.referenceSources) or os.makedirs(args.referenceSources)
   except OSError as e:
     error(str(e))
     exit(1)
 
   # Fetch recipes first if necessary
-  if path.exists(configDir):
-    warning("using existing recipes from %s" % configDir)
+  if path.exists(args.configDir):
+    warning("using existing recipes from %s" % args.configDir)
   else:
     cmd = format("git clone %(repo)s%(branch)s %(cd)s",
-                 repo=dist["repo"] if ":" in dist["repo"] else "https://github.com/%s" % dist["repo"],
-                 branch=" -b "+dist["ver"] if dist["ver"] else "",
-                 cd=configDir)
+                 repo=args.dist["repo"] if ":" in args.dist["repo"] else "https://github.com/%s" % args.dist["repo"],
+                 branch=" -b "+args.dist["ver"] if args.dist["ver"] else "",
+                 cd=args.configDir)
     debug(cmd)
     err = execute(cmd)
     dieOnError(err!=0, "cannot clone recipes")
@@ -49,32 +49,32 @@ def doInit(setdir, configDir, pkgname, referenceSources, dist, defaults, dryRun)
   # Use standard functions supporting overrides and taps. Ignore all disables
   # and system packages as they are irrelevant in this context
   specs = {}
-  defaultsReader = lambda: readDefaults(configDir, defaults, error)
+  defaultsReader = lambda: readDefaults(args.configDir, args.defaults, error)
   (err, overrides, taps) = parseDefaults([], defaultsReader, debug)
   (_,_,_,validDefaults) = getPackageList(packages=[ p["name"] for p in pkgs ],
                                          specs=specs,
-                                         configDir=configDir,
+                                         configDir=args.configDir,
                                          preferSystem=False,
                                          noSystem=True,
                                          architecture="",
                                          disable=[],
-                                         defaults=defaults,
+                                         defaults=args.defaults,
                                          dieOnError=lambda *x, **y: None,
                                          performPreferCheck=lambda *x, **y: (1, ""),
                                          performRequirementCheck=lambda *x, **y: (0, ""),
-                                         performValidateDefaults=lambda spec : validateDefaults(spec, defaults),
+                                         performValidateDefaults=lambda spec : validateDefaults(spec, args.defaults),
                                          overrides=overrides,
                                          taps=taps,
                                          log=debug)
-  dieOnError(validDefaults and defaults not in validDefaults,
-             "Specified default `%s' is not compatible with the packages you want to build.\n" % defaults +
+  dieOnError(validDefaults and args.defaults not in validDefaults,
+             "Specified default `%s' is not compatible with the packages you want to build.\n" % args.defaults +
              "Valid defaults:\n\n- " +
              "\n- ".join(sorted(validDefaults)))
 
   for p in pkgs:
     spec = specs.get(p["name"])
     dieOnError(spec is None, "cannot find recipe for package %s" % p["name"])
-    dest = join(setdir, spec["package"])
+    dest = join(args.develPrefix, spec["package"])
     writeRepo = spec.get("write_repo", spec.get("source"))
     dieOnError(not writeRepo, "package %s has no source field and cannot be developed" % spec["package"])
     if path.exists(dest):
@@ -82,13 +82,19 @@ def doInit(setdir, configDir, pkgname, referenceSources, dist, defaults, dryRun)
       continue
     p["ver"] = p["ver"] if p["ver"] else spec.get("tag", spec["version"])
     debug("cloning %s%s for development" % (spec["package"], " version "+p["ver"] if p["ver"] else ""))
-    updateReferenceRepos(referenceSources, spec["package"], spec)
+
+    if not args.fetchRepos:
+      spec["reference"] = path.join(abspath(args.referenceSources), spec["package"].lower())
+
+    if args.fetchRepos or not path.exists(spec["reference"]):
+      updateReferenceRepos(args.referenceSources, spec["package"], spec)
+
     cmd = format("git clone %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
                  "cd %(cd)s && git remote set-url --push origin %(writeRepo)s",
                  readRepo=spec["source"],
                  writeRepo=writeRepo,
                  branch=" -b "+p["ver"] if p["ver"] else "",
-                 refSource=join(referenceSources, spec["package"].lower()),
+                 refSource=join(args.referenceSources, spec["package"].lower()),
                  cd=dest)
     debug(cmd)
     err = execute(cmd)
@@ -96,4 +102,4 @@ def doInit(setdir, configDir, pkgname, referenceSources, dist, defaults, dryRun)
                        (spec["package"], " version "+p["ver"] if p["ver"] else ""))
   banner(format("Development directory %(d)s created%(pkgs)s",
          pkgs=" for "+", ".join([ x["name"].lower() for x in pkgs ]) if pkgs else "",
-         d=setdir))
+         d=args.develPrefix))

--- a/docs/user.markdown
+++ b/docs/user.markdown
@@ -17,7 +17,8 @@ For a quick start introduction, please look [here](./quick.html).
                     [--always-prefer-system] [--no-system]
                     [--force-unknown-architecture] [--insecure]
                     [--aggressive-cleanup] [--debug] [--no-auto-cleanup]
-                    [--devel-prefix [DEVELPREFIX]] [--dist DIST] [--dry-run]
+                    [--devel-prefix [DEVELPREFIX]] [--dist DIST]
+                    [--dry-run] [--fetch-repos|-u]
                     {init,build,clean} [pkgname]
 
     positional arguments:
@@ -62,6 +63,7 @@ For a quick start introduction, please look [here](./quick.html).
                             recipes set ([user/repo@]branch)
       --dry-run, -n         Prints what would happen, without actually doing the
                             build.
+      --fetch-repos, -u     Fetch repository updates
 
 
 ## Speedup build process by using a build store

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -25,7 +25,7 @@ else:
   ANALYTICS_MISSING_STATE_ERROR = "too few arguments"
 
 # A few errors we should handle, together with the expected result
-ARCHITECTURE_ERROR = [call(u"Unknown / unsupported architecture: foo.\n\nOn Linux, x86-64:\n   RHEL5 / SLC5 compatible: slc5_x86-64\n   RHEL6 / SLC6 compatible: slc6_x86-64\n   RHEL7 / CC7 compatible: slc7_x86-64\n   Ubuntu 14.04 compatible: ubuntu1404_x86-64\n   Ubuntu 15.04 compatible: ubuntu1504_x86-64\n   Ubuntu 15.10 compatible: ubuntu1510_x86-64\n   Ubuntu 16.04 compatible: ubuntu1604_x86-64\n\nOn Linux, POWER8 / PPC64 (little endian):\n   RHEL7 / CC7 compatible: slc7_ppc64\n\nOn Mac, x86-64:\n   Yosemite and El-Captain: osx_x86-64\n\nAlternatively, you can use the `--force-unknown-architecture' option.")]
+ARCHITECTURE_ERROR = [call(u"Unknown / unsupported architecture: foo.\n\nOn Linux, x86-64:\n   RHEL5 / SLC5 compatible: slc5_x86-64\n   RHEL6 / SLC6 compatible: slc6_x86-64\n   RHEL7 / CC7 compatible: slc7_x86-64\n   Ubuntu 14.04 compatible: ubuntu1404_x86-64\n   Ubuntu 15.04 compatible: ubuntu1504_x86-64\n   Ubuntu 15.10 compatible: ubuntu1510_x86-64\n   Ubuntu 16.04 compatible: ubuntu1604_x86-64\n   Fedora 25 compatible: fedora25_x86-64\n   Fedora 26 compatible: fedora26_x86-64\n\nOn Linux, POWER8 / PPC64 (little endian):\n   RHEL7 / CC7 compatible: slc7_ppc64\n\nOn Mac, x86-64:\n   Yosemite and El-Captain: osx_x86-64\n\nAlternatively, you can use the `--force-unknown-architecture' option.")]
 PARSER_ERRORS = {
   "build": [call(BUILD_MISSING_PKG_ERROR)],
   "build zlib --foo": [call('unrecognized arguments: --foo')],


### PR DESCRIPTION
This patch is quite useful when having only a slow or unreliable
Internet connection available, e.g. in trains or planes.

This patch changes the default behaviour of the `{build,init}` subcommands, so that they only clone the reference repos, if they are missing. The user has to pass `--fetch-repos` or `-u` to force fetching updates to the reference repos.

This patch reorganizes the `updateReferenceRepos` calls to before the build loop
and extracts the git heads from the local repos only. ~~If `--offline` flag
is passed the `updateReferenceRepos` calls are skipped.~~

---

Hope, we can take this as a start to resolve #323. What do you think? Still needs testing, just hacked this together half an hour ago ;) But it was really annoying to wait 20 seconds in the train for fetching the git heads on every build.