### PR TITLE
Force use of /bin/bash when checking system deps

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -10,7 +10,7 @@ except ImportError:
 from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, error, info, banner, warning
 from alibuild_helpers.log import dieOnError
-from alibuild_helpers.cmd import execute, getStatusOutputBash, bashInterpreter
+from alibuild_helpers.cmd import execute, getStatusOutputBash, BASH
 from alibuild_helpers.utilities import prunePaths
 from alibuild_helpers.utilities import format, dockerStatusOutput, parseDefaults, readDefaults
 from alibuild_helpers.utilities import getPackageList
@@ -953,7 +953,7 @@ def doBuild(args, parser):
               " %(bash)s -e -x /build.sh",
               additionalEnv=additionalEnv,
               additionalVolumes=additionalVolumes,
-              bash=bashInterpreter(),
+              bash=BASH,
               develVolumes=develVolumes,
               workdir=abspath(args.workDir),
               image=dockerImage,
@@ -966,7 +966,7 @@ def doBuild(args, parser):
       progress = ProgressPrint("%s is being built (use --debug for full output)" % spec["package"])
       for k,v in buildEnvironment:
         os.environ[k] = str(v)
-      err = execute("%s -e -x %s/build.sh 2>&1" % (bashInterpreter(), scriptDir),
+      err = execute("%s -e -x %s/build.sh 2>&1" % (BASH, scriptDir),
                     printer=debug if args.debug or not sys.stdout.isatty() else progress)
       progress.end("failed" if err else "ok", err)
     report_event("BuildError" if err else "BuildSuccess",

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -10,7 +10,7 @@ except ImportError:
 from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, error, info, banner, warning
 from alibuild_helpers.log import dieOnError
-from alibuild_helpers.cmd import execute
+from alibuild_helpers.cmd import execute, getStatusOutputBash, bashInterpreter
 from alibuild_helpers.utilities import prunePaths
 from alibuild_helpers.utilities import format, dockerStatusOutput, parseDefaults, readDefaults
 from alibuild_helpers.utilities import getPackageList
@@ -266,8 +266,8 @@ def doBuild(args, parser):
                                                                         disable                 = args.disable,
                                                                         defaults                = args.defaults,
                                                                         dieOnError              = dieOnError,
-                                                                        performPreferCheck      = lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage),
-                                                                        performRequirementCheck = lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage),
+                                                                        performPreferCheck      = lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage, executor=getStatusOutputBash),
+                                                                        performRequirementCheck = lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage, executor=getStatusOutputBash),
                                                                         performValidateDefaults = lambda spec : validateDefaults(spec, args.defaults),
                                                                         overrides               = overrides,
                                                                         taps                    = taps,
@@ -446,11 +446,6 @@ def doBuild(args, parser):
     logger_handler.setFormatter(
         LogFormatter("%%(levelname)s:%s:%s: %%(message)s" %
                      (mainPackage, args.develPrefix if "develPrefix" in args else mainHash[0:8])))
-
-  # Given we started by enforcing /bin/bash we keep enforcing it, however if
-  # it's somewhere else on system, e.g. on NixOS, we fallback to the one in
-  # path.
-  bashInterpreter = getstatusoutput("/bin/bash --version")[0] and "bash" or "/bin/bash"
 
   # Now that we have the main package set, we can print out Useful information
   # which we will be able to associate with this build. Also lets make sure each package
@@ -958,7 +953,7 @@ def doBuild(args, parser):
               " %(bash)s -e -x /build.sh",
               additionalEnv=additionalEnv,
               additionalVolumes=additionalVolumes,
-              bash=bashInterpreter,
+              bash=bashInterpreter(),
               develVolumes=develVolumes,
               workdir=abspath(args.workDir),
               image=dockerImage,
@@ -971,7 +966,7 @@ def doBuild(args, parser):
       progress = ProgressPrint("%s is being built (use --debug for full output)" % spec["package"])
       for k,v in buildEnvironment:
         os.environ[k] = str(v)
-      err = execute("%s -e -x %s/build.sh 2>&1" % (bashInterpreter, scriptDir),
+      err = execute("%s -e -x %s/build.sh 2>&1" % (bashInterpreter(), scriptDir),
                     printer=debug if args.debug or not sys.stdout.isatty() else progress)
       progress.end("failed" if err else "ok", err)
     report_event("BuildError" if err else "BuildSuccess",

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -3,34 +3,24 @@ try:
 except ImportError:
   from subprocess import getstatusoutput
 from alibuild_helpers.log import debug
-from alibuild_helpers.utilities import is_string, cache
+from alibuild_helpers.utilities import is_string, to_unicode
 import subprocess
 
-@cache
-def bashInterpreter():
-  # Given we started by enforcing /bin/bash we keep enforcing it, however if it's
-  # somewhere else on system, e.g. on NixOS, we fallback to the one in path.
-  return "bash" if getstatusoutput("/bin/bash --version")[0] else "/bin/bash"
+BASH = "bash" if getstatusoutput("/bin/bash --version")[0] else "/bin/bash"
 
 def execute(command, printer=debug):
   popen = subprocess.Popen(command, shell=is_string(command), stdout=subprocess.PIPE)
   lines_iterator = iter(popen.stdout.readline, "")
   for line in lines_iterator:
     if not line: break
-    printer(line.decode('utf-8', 'ignore').strip("\n"))  # yield line
-  output = popen.communicate()[0]
-  printer(output)
-  exitCode = popen.returncode
-  return exitCode
+    printer(to_unicode(line.strip("\n"))) # yield line
+  out = to_unicode(popen.communicate()[0])
+  printer(out)
+  return popen.returncode
 
 def getStatusOutputBash(command):
-  if is_string(command):
-    command = [ bashInterpreter(), "-c", command ]
-  popen = subprocess.Popen(command, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-  lines_iterator = iter(popen.stdout.readline, "")
-  txt = ""
-  for line in lines_iterator:
-    if not line: break
-    txt += line.decode('utf-8', "ignore") # yield line
-  txt += popen.communicate()[0].decode('utf-8', 'ignore')
-  return (popen.returncode, txt)
+  assert is_string(command), "only strings accepted as command"
+  popen = subprocess.Popen([ BASH, "-c", command ], shell=False,
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  out = to_unicode(popen.communicate()[0])
+  return (popen.returncode, out)

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -13,9 +13,9 @@ def execute(command, printer=debug):
   lines_iterator = iter(popen.stdout.readline, "")
   for line in lines_iterator:
     if not line: break
-    printer(to_unicode(line.strip("\n"))) # yield line
+    printer(to_unicode(line).strip("\n")) # yield line
   out = to_unicode(popen.communicate()[0])
-  printer(out)
+  printer(out.strip("\n"))
   return popen.returncode
 
 def getStatusOutputBash(command):

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -1,6 +1,16 @@
+try:
+  from commands import getstatusoutput
+except ImportError:
+  from subprocess import getstatusoutput
 from alibuild_helpers.log import debug
-from alibuild_helpers.utilities import is_string
+from alibuild_helpers.utilities import is_string, cache
 import subprocess
+
+@cache
+def bashInterpreter():
+  # Given we started by enforcing /bin/bash we keep enforcing it, however if it's
+  # somewhere else on system, e.g. on NixOS, we fallback to the one in path.
+  return "bash" if getstatusoutput("/bin/bash --version")[0] else "/bin/bash"
 
 def execute(command, printer=debug):
   popen = subprocess.Popen(command, shell=is_string(command), stdout=subprocess.PIPE)
@@ -13,3 +23,14 @@ def execute(command, printer=debug):
   exitCode = popen.returncode
   return exitCode
 
+def getStatusOutputBash(command):
+  if is_string(command):
+    command = [ bashInterpreter(), "-c", command ]
+  popen = subprocess.Popen(command, shell=False, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+  lines_iterator = iter(popen.stdout.readline, "")
+  txt = ""
+  for line in lines_iterator:
+    if not line: break
+    txt += line.decode('utf-8', "ignore") # yield line
+  txt += popen.communicate()[0].decode('utf-8', 'ignore')
+  return (popen.returncode, txt)

--- a/alibuild_helpers/doctor.py
+++ b/alibuild_helpers/doctor.py
@@ -10,17 +10,8 @@ from alibuild_helpers.log import debug, error, banner, info, success, warning
 from alibuild_helpers.log import logger
 from alibuild_helpers.utilities import getPackageList, format, detectArch, parseDefaults, readDefaults, validateDefaults
 from alibuild_helpers.utilities import dockerStatusOutput
+from alibuild_helpers.cmd import getStatusOutputBash
 import subprocess
-
-def execute(command):
-  popen = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-  lines_iterator = iter(popen.stdout.readline, "")
-  txt = ""
-  for line in lines_iterator:
-    if not line: break
-    txt += line.decode('utf-8', "ignore") # yield line
-  txt += popen.communicate()[0].decode('utf-8', 'ignore')
-  return (popen.returncode, txt)
 
 def prunePaths(workDir):
   for x in ["PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"]:
@@ -34,7 +25,7 @@ def checkPreferSystem(spec, cmd, homebrew_replacement, dockerImage):
       debug("Package %s can only be managed via alibuild." % spec["package"])
       return (1, "")
     cmd = homebrew_replacement + cmd
-    err, out = dockerStatusOutput(cmd, dockerImage=dockerImage, executor=execute)
+    err, out = dockerStatusOutput(cmd, dockerImage=dockerImage, executor=getStatusOutputBash)
     if not err:
       success("Package %s will be picked up from the system." % spec["package"])
       for x in out.split("\n"):
@@ -56,7 +47,7 @@ def checkRequirements(spec, cmd, homebrew_replacement, dockerImage):
       debug("Package %s is not a system requirement." % spec["package"])
       return (0, "")
     cmd = homebrew_replacement + cmd
-    err, out = dockerStatusOutput(cmd, dockerImage=dockerImage, executor=execute)
+    err, out = dockerStatusOutput(cmd, dockerImage=dockerImage, executor=getStatusOutputBash)
     if not err:
       success("Required package %s will be picked up from the system." % spec["package"])
       debug(cmd)

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -22,18 +22,6 @@ class SpecError(Exception):
 
 asList = lambda x : x if type(x) == list else [x]
 
-# Aggressive cache decorator for any function
-class cache:
-  def __init__(self, f):
-    self.f = f
-    self.res = None
-    self.res_set = False
-  def __call__(self, *x, **y):
-    if not self.res_set:
-      self.res = self.f(*x, **y)
-      self.res_set = True
-    return self.res
-
 def is_string(s):
   if sys.version_info[0] >= 3:
     return isinstance(s, str)

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -22,6 +22,18 @@ class SpecError(Exception):
 
 asList = lambda x : x if type(x) == list else [x]
 
+# Aggressive cache decorator for any function
+class cache:
+  def __init__(self, f):
+    self.f = f
+    self.res = None
+    self.res_set = False
+  def __call__(self, *x, **y):
+    if not self.res_set:
+      self.res = self.f(*x, **y)
+      self.res_set = True
+    return self.res
+
 def is_string(s):
   if sys.version_info[0] >= 3:
     return isinstance(s, str)

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -16,11 +16,11 @@ class CmdTestCase(unittest.TestCase):
     def test_execute(self, mock_debug):
       err = execute("echo foo", mock_debug)
       self.assertEqual(err, 0)
-      self.assertEqual(mock_debug.mock_calls, [call('foo'), call(b'')])
+      self.assertEqual(mock_debug.mock_calls, [call('foo'), call('')])
       mock_debug.reset_mock()
       err = execute("echoo 2> /dev/null", mock_debug)
       self.assertEqual(err, 127)
-      self.assertEqual(mock_debug.mock_calls, [call(b'')])
+      self.assertEqual(mock_debug.mock_calls, [call('')])
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
(Also move Bash detection to cmd module and cache result.)

This fixes a serious problem when checking system packages: we assume the syntax is Bash's (therefore we are not POSIX-compliant), but we cannot rely on Python's shell choice. By default it's `/bin/sh`, which on _some_ Ubuntu systems is `/bin/bash` (OK), but on a large number it's `/bin/dash` (POSIX: not OK for us).

We need to make sure checks are executed in Bash.

Code for automatic detection of Bash (`/bin/bash`, `bash`) has been reused.