### PR TITLE
Allow read-only references

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -372,7 +372,7 @@ def doBuild(args, parser):
 
     specs[p]["git_heads"] = output
 
-  # Resolve the tag to the actual commit ref, so that
+  # Resolve the tag to the actual commit ref
   for p in buildOrder:
     spec = specs[p]
     spec["commit_hash"] = "0"
@@ -980,7 +980,7 @@ def doBuild(args, parser):
 
     buildErrMsg = format("Error while executing %(sd)s/build.sh on `%(h)s'.\n"
                          "Log can be found in %(w)s/BUILD/%(p)s-latest%(devSuffix)s/log.\n"
-                         "Please upload it to CernBox/DropBox if you intend to request support.\n"
+                         "Please upload it to CERNBox/Dropbox if you intend to request support.\n"
                          "Build directory is %(w)s/BUILD/%(p)s-latest%(devSuffix)s/%(p)s.",
                          h=socket.gethostname(),
                          sd=scriptDir,

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -29,20 +29,22 @@ def updateReferenceRepos(referenceSources, p, spec):
   assert(type(spec) == OrderedDict)
   debug("Updating references.")
   referenceRepo = "%s/%s" % (abspath(referenceSources), p.lower())
-  if os.access(dirname(referenceSources), os.W_OK):
+
+  if is_writeable(dirname(referenceSources)):
     getstatusoutput("mkdir -p %s" % referenceSources)
-  writeableReference = os.access(referenceSources, os.W_OK)
-  if not writeableReference and path.exists(referenceRepo):
-    debug("Using %s as reference for %s." % (referenceRepo, p))
-    spec["reference"] = referenceRepo
-    return
-  if not writeableReference:
-    debug("Cannot create reference for %s in specified folder.", p)
+
+  if not is_writeable(referenceSources):
+    if path.exists(referenceRepo):
+      debug("Using %s as reference for %s." % (referenceRepo, p))
+      spec["reference"] = referenceRepo
+    else:
+      debug("Cannot create reference for %s in %s" % (p, referenceSources))
     return
 
   err, out = getstatusoutput("mkdir -p %s" % abspath(referenceSources))
   if not "source" in spec:
     return
+
   if not path.exists(referenceRepo):
     cmd = ["git", "clone", "--bare", spec["source"], referenceRepo]
     debug(" ".join(cmd))
@@ -56,3 +58,6 @@ def updateReferenceRepos(referenceSources, p, spec):
   dieOnError(err, "Error while updating reference repos %s." % spec["source"])
   spec["reference"] = referenceRepo
 
+
+def is_writeable(path):
+  return os.access(path, os.W_OK)

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -9,6 +9,7 @@ from alibuild_helpers.utilities import format
 
 import os
 import os.path as path
+import tempfile
 try:
   from collections import OrderedDict
 except ImportError:
@@ -62,6 +63,9 @@ def updateReferenceRepos(referenceSources, p, spec, fetch=True):
   dieOnError(err, "Error while updating reference repos %s." % spec["source"])
   spec["reference"] = referenceRepo  # read-write
 
-
-def is_writeable(path):
-  return os.access(path, os.W_OK)
+def is_writeable(dirpath):
+  try:
+    with tempfile.NamedTemporaryFile(dir=dirpath):
+      return True
+  except:
+    return False


### PR DESCRIPTION
If a mirror is read-only, ignore it and move on, otherwise fetch
the heads.