### PR TITLE
Ensure we fetch ALL heads when updating reference

### DIFF
--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -74,7 +74,7 @@ def updateReferenceRepo(referenceSources, p, spec, fetch=True):
   elif fetch:
     cmd = format("cd %(referenceRepo)s && "
                  "git fetch --tags %(source)s 2>&1 && "
-                 "git fetch %(source)s 2>&1",
+                 "git fetch %(source)s 'refs/heads/*:refs/heads/*' 2>&1",
                  referenceRepo=referenceRepo,
                  source=spec["source"])
     debug("Updating reference repository: %s" % cmd)


### PR DESCRIPTION
`git fetch` does not fetch all upstream branches by default, just the HEAD