### PR TITLE
Allow force-updating from remote references

### DIFF
--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -74,7 +74,7 @@ def updateReferenceRepo(referenceSources, p, spec, fetch=True):
   elif fetch:
     cmd = format("cd %(referenceRepo)s && "
                  "git fetch --tags %(source)s 2>&1 && "
-                 "git fetch %(source)s 'refs/heads/*:refs/heads/*' 2>&1",
+                 "git fetch %(source)s '+refs/heads/*:refs/heads/*' 2>&1",
                  referenceRepo=referenceRepo,
                  source=spec["source"])
     debug("Updating reference repository: %s" % cmd)


### PR DESCRIPTION
See the `refspec` description on `man git-push`. Initial `+` is required to allow for local references to be force-updated (non-fast-forward)