### PR TITLE
Disable shell hash command as hashing is disabled

### DIFF
--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -4,6 +4,7 @@
 
 set -e
 set +h
+function hash() { true; }
 export WORK_DIR="${WORK_DIR_OVERRIDE:-%(workDir)s}"
 
 # From our dependencies


### PR DESCRIPTION
When using `set +h`, the `hash` command returns nonzero with a warning saying
that hashing is disabled. To prevent recipes using `hash` to fail without
changing them, the `hash` command is being aliased to a no-op.

Note that this was introduced in #503 since:

* hashing is disabled in the `build_template.sh` shell environment,
* the recipe turned from being executed in a separate shell to being sourced in
  the current shell (thus retaining the `set +h` option).