### PR TITLE
build: Fix handling of command-line environment variables

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -903,8 +903,9 @@ def doBuild(args, parser):
       ("WRITE_REPO", spec.get("write_repo", source)),
     ]
     # Add the extra environment as passed from the command line.
-    for e in [x.split("=", "1") for x in args.environment]:
-      buildEnvironment.append(e)
+    for e in args.environment:
+        key, _eq, value = e.partition("=")
+        buildEnvironment.append((key, value))
     # In case the --docker options is passed, we setup a docker container which
     # will perform the actual build. Otherwise build as usual using bash.
     if args.docker:
@@ -1002,3 +1003,4 @@ def doBuild(args, parser):
                   devSuffix="-"+args.develPrefix if "develPrefix" in args else "",
                   w=abspath(args.workDir)))
   return (debug, "Everything done", 0)
+

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -215,16 +215,6 @@ def createDistLinks(spec, specs, args, repoType, requiresType):
                  t=target)
     execute(cmd)
 
-def parse_environment_arguments(environment):
-    """
-    Split strings into key-value pairs, using '=' as delimiter
-    """
-    result = []
-    for e in environment:
-        key, _eq, value = e.partition("=")
-        result.append((key, value))
-    return result
-
 def doBuild(args, parser):
   if args.remoteStore.startswith("http"):
     syncHelper = HttpRemoteSync(args.remoteStore, args.architecture, args.workDir, args.insecure)
@@ -913,7 +903,7 @@ def doBuild(args, parser):
       ("WRITE_REPO", spec.get("write_repo", source)),
     ]
     # Add the extra environment as passed from the command line.
-    buildEnvironment += parse_environment_arguments(args.environment)
+    buildEnvironment += [e.partition('=')[::2] for e in args.environment]
     # In case the --docker options is passed, we setup a docker container which
     # will perform the actual build. Otherwise build as usual using bash.
     if args.docker:

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -215,6 +215,16 @@ def createDistLinks(spec, specs, args, repoType, requiresType):
                  t=target)
     execute(cmd)
 
+def parse_environment_arguments(environment):
+    """
+    Split strings into key-value pairs, using '=' as delimiter
+    """
+    result = []
+    for e in environment:
+        key, _eq, value = e.partition("=")
+        result.append((key, value))
+    return result
+
 def doBuild(args, parser):
   if args.remoteStore.startswith("http"):
     syncHelper = HttpRemoteSync(args.remoteStore, args.architecture, args.workDir, args.insecure)
@@ -903,9 +913,7 @@ def doBuild(args, parser):
       ("WRITE_REPO", spec.get("write_repo", source)),
     ]
     # Add the extra environment as passed from the command line.
-    for e in args.environment:
-        key, _eq, value = e.partition("=")
-        buildEnvironment.append((key, value))
+    buildEnvironment += parse_environment_arguments(args.environment)
     # In case the --docker options is passed, we setup a docker container which
     # will perform the actual build. Otherwise build as usual using bash.
     if args.docker:

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
 # Assuming you are using the mock library to ... mock things
 try:
+    from unittest import mock
     from unittest.mock import patch, call  # In Python 3, mock is built-in
 except ImportError:
+    import mock
     from mock import patch, call  # Python 2
 
 import alibuild_helpers.args
@@ -12,7 +14,6 @@ import sys
 import os
 import os.path
 
-import mock
 import unittest
 import traceback
 import shlex

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -257,12 +257,6 @@ class BuildTestCase(unittest.TestCase):
       x.syncToLocal("zlib", dummy_spec)
       x.syncToRemote("zlib", dummy_spec)
 
-  def test_parse_environment_arguments(self):
-      from alibuild_helpers.build import parse_environment_arguments
-      args = parse_environment_arguments(["A=b", "B=c", "C"])
-      self.assertEqual(args[0], ("A", "b"))
-      self.assertEqual(args[1], ("B", "c"))
-      self.assertEqual(args[2], ("C", ""))
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -19,7 +19,6 @@ import os
 import os.path
 import re
 
-import mock
 import unittest
 import traceback
 
@@ -257,6 +256,13 @@ class BuildTestCase(unittest.TestCase):
     for x in syncers:
       x.syncToLocal("zlib", dummy_spec)
       x.syncToRemote("zlib", dummy_spec)
+
+  def test_parse_environment_arguments(self):
+      from alibuild_helpers.build import parse_environment_arguments
+      args = parse_environment_arguments(["A=b", "B=c", "C"])
+      self.assertEqual(args[0], ("A", "b"))
+      self.assertEqual(args[1], ("B", "c"))
+      self.assertEqual(args[2], ("C", ""))
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
If environment variables were specified in the command line via `-e` arguments, the build script would try to split the value on `=`, but erroneously passed the string `'1'` (not the integer `1`) into `str.split`.

This fix uses `str.partition` to split on 0 or 1 instances of '=' (the zero case will store the empty string into the environment variable)