### PR TITLE
Set aliDeps temp file mode to text

### DIFF
--- a/alibuild_helpers/deps.py
+++ b/alibuild_helpers/deps.py
@@ -87,9 +87,9 @@ def doDeps(args, parser):
   dot += "}\n"
 
   if args.outdot:
-    fp = open(args.outdot, "w")
+    fp = open(args.outdot, "wt")
   else:
-    fp = NamedTemporaryFile(delete=False)
+    fp = NamedTemporaryFile(delete=False, mode="wt")
   fp.write(dot)
   fp.close()
 

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -75,5 +75,9 @@ class DepsTestCase(unittest.TestCase):
 
     doDeps(args, MagicMock())
 
+    # Same check without explicit intermediate dotfile
+    args.outdot = None
+    doDeps(args, MagicMock())
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Python 3 writes bytes, not strings. Writing pure text allows us to pass strings
to `write()` as well.

Fixes #556.