### PR TITLE
Force fetch mirrored tags / branches

### DIFF
--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -73,8 +73,8 @@ def updateReferenceRepo(referenceSources, p, spec, fetch=True):
     err = execute(cmd)
   elif fetch:
     cmd = format("cd %(referenceRepo)s && "
-                 "git fetch --tags %(source)s 2>&1 && "
-                 "git fetch %(source)s '+refs/heads/*:refs/heads/*' 2>&1",
+                 "git fetch -f --tags %(source)s 2>&1 && "
+                 "git fetch -f %(source)s '+refs/heads/*:refs/heads/*' 2>&1",
                  referenceRepo=referenceRepo,
                  source=spec["source"])
     debug("Updating reference repository: %s" % cmd)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -122,7 +122,7 @@ def dummy_execute(x, mock_git_clone, mock_git_fetch, **kwds):
     return 0
   if re.search("^git clone --bare", s):
     mock_git_clone()
-  elif re.search("&& git fetch --tags", s):
+  elif re.search("&& git fetch -f --tags", s):
     mock_git_fetch()
     return 0
   return {

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -40,7 +40,7 @@ def allow_git_clone(x, mock_git_clone, mock_git_fetch, **k):
   s = " ".join(x) if isinstance(x, list) else x
   if re.search("^git clone ", s):
     mock_git_clone()
-  elif re.search("&& git fetch --tags", s):
+  elif re.search("&& git fetch -f --tags", s):
     mock_git_fetch()
   return 0
 


### PR DESCRIPTION
The idea is that if someone moves a tag upstream, we should
still be able to fetch the new one and rebuild. This should be
transparently handled by aliBuild in any case, since alibuild
resolves the commit hash to create the packaging hash.