### PR TITLE
WIP: Don't MIRROR sources if there is a prebuilt tar in remote store

### DIFF
--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -94,6 +94,8 @@ def doParseArgs(star):
                       dest="develPrefix", default=argparse.SUPPRESS)
   build_parser.add_argument("--fetch-repos", "-u", dest="fetchRepos", default=False,
                             action="store_true", help="Fetch repository updates")
+  build_parser.add_argument("--force-clone-repos", dest="forceCloneRepos", default=False,
+                            action="store_true", help="Clone repositories for pre-built packages")
 
   group = build_parser.add_mutually_exclusive_group()
   group.add_argument("--always-prefer-system", dest="preferSystem", default=False,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -83,6 +83,8 @@ def dummy_getstatusoutput(x):
     return (0, "")
   if re.match("ln -snf[^;]*$", x):
     return (0, "")
+  if x.startswith("cd /sw; "):
+    return (0, "")
   return {
       "GIT_DIR=/alidist/.git git rev-parse HEAD": (0, "6cec7b7b3769826219dfa85e5daa6de6522229a0"),
       'pip --disable-pip-version-check show alibuild | grep -e "^Version:" | sed -e \'s/.* //\'': (0, "v1.5.0"),


### PR DESCRIPTION
So, this stops aliBuild from MIRRORing sources (at least for me). Basically I continued to violate the DRY principle and now the python code not only creates symlinks but does almost everything what `build_template.sh:# Unpack, and relocate` does: https://github.com/alisw/alibuild/blob/930f10efa9bd253f44e7f44bcfc54d4001c8e467/alibuild_helpers/build_template.sh#L263-L274
WIP because I suspect this won't work with Docker. I would like to get some feedback on the direction before trying to make this work in Docker. @sawenzel, @ktf, @dberzano ?