### PR TITLE
Drop DYLD_LIBRARY_PATH usage

### DIFF
--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 # Automatically generated build script
+unset DYLD_LIBRARY_PATH
 
 set -e
 set +h
@@ -111,13 +112,13 @@ cd "$BUILDDIR"
 #   the relocation script so that it takes into account the new location.
 if [[ "$CACHED_TARBALL" == "" && ! -f $BUILDROOT/log ]]; then
   set -o pipefail
-  (set -x; source "$WORK_DIR/SPECS/$ARCHITECTURE/$PKGNAME/$PKGVERSION-$PKGREVISION/$PKGNAME.sh" 2>&1) | tee "$BUILDROOT/log"
+  (set -x; unset DYLD_LIBRARY_PATH; source "$WORK_DIR/SPECS/$ARCHITECTURE/$PKGNAME/$PKGVERSION-$PKGREVISION/$PKGNAME.sh" 2>&1) | tee "$BUILDROOT/log"
 elif [[ "$CACHED_TARBALL" == "" && $INCREMENTAL_BUILD_HASH != "0" && -f "$BUILDDIR/.build_succeeded" ]]; then
   set -o pipefail
   (%(incremental_recipe)s) 2>&1 | tee "$BUILDROOT/log"
 elif [[ "$CACHED_TARBALL" == "" ]]; then
   set -o pipefail
-  (set -x; source "$WORK_DIR/SPECS/$ARCHITECTURE/$PKGNAME/$PKGVERSION-$PKGREVISION/$PKGNAME.sh" 2>&1) | tee "$BUILDROOT/log"
+  (set -x; unset DYLD_LIBRARY_PATH; source "$WORK_DIR/SPECS/$ARCHITECTURE/$PKGNAME/$PKGVERSION-$PKGREVISION/$PKGNAME.sh" 2>&1) | tee "$BUILDROOT/log"
 else
   # Unpack the cached tarball in the $INSTALLROOT and remove the unrelocated
   # files.

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -42,7 +42,9 @@ def normalise_multiple_options(option, sep=","):
   return [x for x in ",".join(option).split(sep) if x]
 
 def prunePaths(workDir):
-  for x in ["PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"]:
+  if "DYLD_LIBRARY_PATH" in os.environ:
+    os.environ.pop("DYLD_LIBRARY_PATH")
+  for x in ["PATH", "LD_LIBRARY_PATH"]:
     if not x in os.environ:
       continue
     workDirEscaped = re.escape("%s" % workDir) + "[^:]*:?"

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -42,9 +42,7 @@ def normalise_multiple_options(option, sep=","):
   return [x for x in ",".join(option).split(sep) if x]
 
 def prunePaths(workDir):
-  if "DYLD_LIBRARY_PATH" in os.environ:
-    os.environ.pop("DYLD_LIBRARY_PATH")
-  for x in ["PATH", "LD_LIBRARY_PATH"]:
+  for x in ["PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"]:
     if not x in os.environ:
       continue
     workDirEscaped = re.escape("%s" % workDir) + "[^:]*:?"

--- a/docs/reference.markdown
+++ b/docs/reference.markdown
@@ -78,13 +78,9 @@ The following entries are optional in the header:
         prepend_path:
           "PATH": "$FOO_ROOT/binexec/foobar"
           "LD_LIBRARY_PATH": [ "$FOO_ROOT/sub/lib", "$FOO_ROOT/sub/lib64" ]
-          "DYLD_LIBRARY_PATH":
-            - "$FOO_ROOT/sub/lib"
-            - "$FOO_ROOT/sub/lib64
 
     will result in prepending `$FOO_ROOT/binexec/foobar` to `$PATH`, and both
-    `$FOO_ROOT/sub/lib` and `lib64` to `LD_LIBRARY_PATH` and
-    `DYLD_LIBRARY_PATH`.
+    `$FOO_ROOT/sub/lib` and `lib64` to `LD_LIBRARY_PATH`.
   - `append_path`: same as `prepend_path` but paths are appended rather than
     prepended.
   - `requires`: a list of run-time and build-time dependency for the package. E.g.:


### PR DESCRIPTION
DYLD_LIBRARY_PATH does not work anymore in subshells if SIP is enabled.
Since we have long switched to @rpath on mac, we can finally drop
these so that we also avoid issues with conflicting library versions.