### PR TITLE
More fixes

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -317,7 +317,7 @@ def createDistLinks(spec, specs, args, repoType, requiresType):
     cmd = format("cd %(w)s && "
                  "for x in `find %(t)s -type l`; do"
                  "  HASHEDURL=`readlink $x | sed -e 's|.*/[.][.]/TARS|TARS|'` &&"
-                 "  echo $HASHEDURL | s3cmd put -q -P -s --add-header=\"x-amz-website-redirect-location:https://s3.cern.ch/swift/v1/%(b)s/${HASHEDURL}\" --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch - s3://%(b)s/$x 2>/dev/null;"
+                 "  echo $HASHEDURL | s3cmd put --skip-existing -q -P -s --add-header=\"x-amz-website-redirect-location:https://s3.cern.ch/swift/v1/%(b)s/${HASHEDURL}\" --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch - s3://%(b)s/$x 2>/dev/null;"
                  "done",
                  w=args.workDir,
                  b=bucket,

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -14,8 +14,9 @@ def execute(command, printer=debug):
   for line in lines_iterator:
     if not line: break
     printer(to_unicode(line).strip("\n")) # yield line
-  out = to_unicode(popen.communicate()[0])
-  printer(out.strip("\n"))
+  out = to_unicode(popen.communicate()[0]).strip("\n")
+  if out:
+    printer(out)
   return popen.returncode
 
 def getStatusOutputBash(command):


### PR DESCRIPTION
* Skip existing links on S3, just like rsync
* Finally get rid of extra empty spaces when execute returns "\n"