### PR TITLE
WIP: Use --filter=blob:none

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 addons:
   apt:
     packages:

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -14,6 +14,7 @@ from alibuild_helpers.utilities import getPackageList
 from alibuild_helpers.utilities import validateDefaults
 from alibuild_helpers.utilities import Hasher
 from alibuild_helpers.utilities import yamlDump
+from alibuild_helpers.git import partialCloneFilter
 import yaml
 from alibuild_helpers.workarea import updateReferenceRepoSpec
 from alibuild_helpers.log import logger_handler, LogFormatter, ProgressPrint
@@ -936,6 +937,10 @@ def doBuild(args, parser):
     if "reference" in spec:
       referenceStatement = "export GIT_REFERENCE=${GIT_REFERENCE_OVERRIDE:-%s}/%s" % (dirname(spec["reference"]), basename(spec["reference"]))
 
+    partialCloneStatement = ""
+    if partialCloneFilter:
+      partialCloneStatement = "export GIT_PARTIAL_CLONE_FILTER='--filter=blob:none'"
+
     debug(spec)
 
     cmd_raw = ""
@@ -975,6 +980,7 @@ def doBuild(args, parser):
                  sourceDir=source and (dirname(source) + "/") or "",
                  sourceName=source and basename(source) or "",
                  referenceStatement=referenceStatement,
+                 partialCloneStatement=partialCloneStatement,
                  requires=" ".join(spec["requires"]),
                  build_requires=" ".join(spec["build_requires"]),
                  runtime_requires=" ".join(spec["runtime_requires"])

--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -79,12 +79,13 @@ fi
 
 # Reference statements
 %(referenceStatement)s
+%(partialCloneStatement)s
 
 if [[ ! "$SOURCE0" == '' && "${SOURCE0:0:1}" != "/" ]]; then
   if [[ ! -d "$SOURCEDIR" ]]; then
     # In case there is a stale link / file, for whatever reason.
     rm -rf $SOURCEDIR
-    git clone ${GIT_REFERENCE:+--reference $GIT_REFERENCE} "$SOURCE0" "$SOURCEDIR"
+    git clone ${GIT_PARTIAL_CLONE_FILTER} ${GIT_REFERENCE:+--reference $GIT_REFERENCE} "$SOURCE0" "$SOURCEDIR"
     cd $SOURCEDIR
     git remote set-url --push origin $WRITE_REPO
     git checkout -f "${GIT_TAG}"

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -1,0 +1,10 @@
+try:
+  from commands import getstatusoutput
+except ImportError:
+  from subprocess import getstatusoutput
+
+def __partialCloneFilter():
+  err, out = getstatusoutput("LANG=C git clone --filter=blob:none 2>&1 | grep 'unknown option'")
+  return err and "--filter=blob:none" or ""
+
+partialCloneFilter = __partialCloneFilter()

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -3,6 +3,7 @@ from alibuild_helpers.utilities import format
 from alibuild_helpers.utilities import parseRecipe, getPackageList, getRecipeReader, parseDefaults, readDefaults, validateDefaults
 from alibuild_helpers.log import debug, error, warning, banner, info
 from alibuild_helpers.log import dieOnError
+from alibuild_helpers.git import partialCloneFilter
 from alibuild_helpers.workarea import updateReferenceRepoSpec
 
 from os.path import abspath, basename, join
@@ -38,7 +39,8 @@ def doInit(args):
   if path.exists(args.configDir):
     warning("using existing recipes from %s" % args.configDir)
   else:
-    cmd = format("git clone %(repo)s%(branch)s %(cd)s",
+    cmd = format("git clone %(pcf)s %(repo)s%(branch)s %(cd)s",
+                 pcf=partialCloneFilter,
                  repo=args.dist["repo"] if ":" in args.dist["repo"] else "https://github.com/%s" % args.dist["repo"],
                  branch=" -b "+args.dist["ver"] if args.dist["ver"] else "",
                  cd=args.configDir)
@@ -84,8 +86,9 @@ def doInit(args):
     debug("cloning %s%s for development" % (spec["package"], " version "+p["ver"] if p["ver"] else ""))
 
     updateReferenceRepoSpec(args.referenceSources, spec["package"], spec, True)
-    cmd = format("git clone %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
+    cmd = format("git clone %(pcf)s %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
                  "cd %(cd)s && git remote set-url --push origin %(writeRepo)s",
+                 pcf=partialCloneFilter,
                  readRepo=spec["source"],
                  writeRepo=writeRepo,
                  branch=" -b "+p["ver"] if p["ver"] else "",

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -1,5 +1,6 @@
 from alibuild_helpers.log import dieOnError, debug
 from alibuild_helpers.cmd import execute
+from alibuild_helpers.git import partialCloneFilter
 from os.path import dirname, abspath
 try:
   from commands import getstatusoutput
@@ -68,7 +69,8 @@ def updateReferenceRepo(referenceSources, p, spec, fetch=True):
 
   err = False
   if not path.exists(referenceRepo):
-    cmd = ["git", "clone", "--bare", spec["source"], referenceRepo]
+    cmd = ["git", "clone", partialCloneFilter, "--bare", spec["source"], referenceRepo]
+    cmd = [x for x in cmd if x]
     debug("Cloning reference repository: %s" % " ".join(cmd))
     err = execute(cmd)
   elif fetch:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,12 +10,14 @@ try:
   from collections import OrderedDict
 except ImportError:
   from ordereddict import OrderedDict
+import sys
+git_mock = MagicMock(partialCloneFilter="--filter=blob:none")
+sys.modules["alibuild_helpers.git"] = git_mock
 
 from alibuild_helpers.build import doBuild, HttpRemoteSync, RsyncRemoteSync, NoRemoteSync
 from alibuild_helpers.analytics import decideAnalytics, askForAnalytics, report_screenview, report_exception, report_event
 from argparse import Namespace
 from io import BytesIO
-import sys
 import os
 import os.path
 import re
@@ -123,7 +125,7 @@ def dummy_execute(x, mock_git_clone, mock_git_fetch, **kwds):
   s = " ".join(x) if isinstance(x, list) else x
   if re.match(".*ln -sfn.*TARS", s):
     return 0
-  if re.search("^git clone --bare", s):
+  if re.search("^git clone --filter=blob:none --bare", s):
     mock_git_clone()
   elif re.search("&& git fetch -f --tags", s):
     mock_git_fetch()
@@ -132,8 +134,8 @@ def dummy_execute(x, mock_git_clone, mock_git_fetch, **kwds):
     "/bin/bash -e -x /sw/SPECS/osx_x86-64/defaults-release/v1-1/build.sh 2>&1": 0,
     '/bin/bash -e -x /sw/SPECS/osx_x86-64/zlib/v1.2.3-1/build.sh 2>&1': 0,
     '/bin/bash -e -x /sw/SPECS/osx_x86-64/ROOT/v6-08-30-1/build.sh 2>&1': 0,
-    "git clone --bare https://github.com/star-externals/zlib /sw/MIRROR/zlib": 0,
-    "git clone --bare https://github.com/root-mirror/root /sw/MIRROR/root": 0
+    "git clone --filter=blob:none --bare https://github.com/star-externals/zlib /sw/MIRROR/zlib": 0,
+    "git clone --filter=blob:none --bare https://github.com/root-mirror/root /sw/MIRROR/root": 0,
   }[s]
 
 def dummy_readlink(x):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,15 +1,19 @@
 from __future__ import print_function
 # Assuming you are using the mock library to ... mock things
 try:
-    from unittest.mock import patch, call  # In Python 3, mock is built-in
+    from unittest.mock import patch, call, MagicMock  # In Python 3, mock is built-in
     from io import StringIO
 except ImportError:
-    from mock import patch, call  # Python 2
+    from mock import patch, call, MagicMock  # Python 2
     from StringIO import StringIO
 try:
   from collections import OrderedDict
 except ImportError:
   from ordereddict import OrderedDict
+import sys
+
+git_mock = MagicMock(partialCloneFilter="--filter=blob:none")
+sys.modules["alibuild_helpers.git"] = git_mock
 from alibuild_helpers.init import doInit,parsePackagesDefinition
 import mock
 import unittest
@@ -37,8 +41,8 @@ def dummy_exists(x):
   return False
 
 CLONE_EVERYTHING = [
- call(u'git clone https://github.com/alisw/alidist -b master /alidist'),
- call(u'git clone https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot')
+ call(u'git clone --filter=blob:none https://github.com/alisw/alidist -b master /alidist'),
+ call(u'git clone --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot')
 ]
 
 class InitTestCase(unittest.TestCase):
@@ -100,7 +104,7 @@ class InitTestCase(unittest.TestCase):
         fetchRepos = False
       )
       doInit(args)
-      mock_execute.assert_called_with("git clone https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot")
+      mock_execute.assert_called_with("git clone --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot")
       self.assertEqual(mock_execute.mock_calls, CLONE_EVERYTHING)
       mock_path.exists.assert_has_calls([call('.'), call('/sw/MIRROR'), call('/alidist'), call('./AliRoot')])
 
@@ -109,7 +113,7 @@ class InitTestCase(unittest.TestCase):
       mock_path.reset_mock()
       args.fetchRepos = True
       doInit(args)
-      mock_execute.assert_called_with("git clone https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot")
+      mock_execute.assert_called_with("git clone --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot")
       self.assertEqual(mock_execute.mock_calls, CLONE_EVERYTHING)
       mock_path.exists.assert_has_calls([call('.'), call('/sw/MIRROR'), call('/alidist'), call('./AliRoot')])
 


### PR DESCRIPTION
Now that Github support partial clones, we can probably greatly
reduce the amount of space taken by source checkouts by adding
the --filter=blob:none option to git clone.

Such an option will make sure that only the blobs which are
of interest for the current checkout are downloaded.

Full docs at https://git-scm.com/docs/partial-clone

The only caveat will be to detect when the client (most notably CC7)
supports it (C8, macOS and Ubuntu are all fine).