### PR TITLE
Show debug output from s3cmd

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -265,7 +265,7 @@ class S3RemoteSync:
 
   def syncToLocal(self, p, spec):
     debug("Updating remote store for package %s@%s" % (p, spec["hash"]))
-    cmd = format(
+    cmd = format("set -x\n"
                  "mkdir -p %(tarballHashDir)s\n"
                  "s3cmd sync -s -v --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch s3://%(b)s/%(storePath)s/ %(tarballHashDir)s/ 2>/dev/null || true\n"
                  "for x in `s3cmd ls -s --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch s3://%(b)s/%(linksPath)s/ 2>/dev/null | sed -e 's|.*s3://|s3://|'`; do"
@@ -286,7 +286,7 @@ class S3RemoteSync:
     tarballNameWithRev = format("%(package)s-%(version)s-%(revision)s.%(architecture)s.tar.gz",
                                 architecture=self.architecture,
                                 **spec)
-    cmd = format("cd %(workdir)s && "
+    cmd = format("set -x; cd %(workdir)s && "
                  "TARSHA256=`sha256sum %(storePath)s/%(tarballNameWithRev)s | awk '{ print $1 }'` && "
                  "s3cmd put -s -v --host s3.cern.ch --add-header \"x-amz-meta-sha256:$TARSHA256\" --host-bucket %(b)s.s3.cern.ch %(storePath)s/%(tarballNameWithRev)s s3://%(b)s/%(storePath)s/ 2>/dev/null || true\n"
                  "HASHEDURL=`readlink %(linksPath)s/%(tarballNameWithRev)s | sed -e's|^../../||'` &&"

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -328,10 +328,10 @@ def createDistLinks(spec, specs, args, repoType, requiresType):
   rsyncOptions = ""
   if args.writeStore.startswith("s3://"):
     bucket = re.sub("^s3://", "", args.writeStore)
-    cmd = format("cd %(w)s && "
+    cmd = format("set -x; cd %(w)s && "
                  "for x in `find %(t)s -type l`; do"
                  "  HASHEDURL=`readlink $x | sed -e 's|.*/[.][.]/TARS|TARS|'` &&"
-                 "  echo $HASHEDURL | s3cmd put --skip-existing -q -P -s --add-header=\"x-amz-website-redirect-location:https://s3.cern.ch/swift/v1/%(b)s/${HASHEDURL}\" --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch - s3://%(b)s/$x 2>/dev/null;"
+                 "  echo $HASHEDURL | s3cmd put --skip-existing -q -P -s --add-header=\"x-amz-website-redirect-location:https://s3.cern.ch/swift/v1/%(b)s/${HASHEDURL}\" --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch - s3://%(b)s/$x;"
                  "done",
                  w=args.workDir,
                  b=bucket,

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -267,10 +267,10 @@ class S3RemoteSync:
     debug("Updating remote store for package %s@%s" % (p, spec["hash"]))
     cmd = format("set -x\n"
                  "mkdir -p %(tarballHashDir)s\n"
-                 "s3cmd sync -s -v --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch s3://%(b)s/%(storePath)s/ %(tarballHashDir)s/ 2>/dev/null || true\n"
-                 "for x in `s3cmd ls -s --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch s3://%(b)s/%(linksPath)s/ 2>/dev/null | sed -e 's|.*s3://|s3://|'`; do"
+                 "s3cmd sync -s -v --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch s3://%(b)s/%(storePath)s/ %(tarballHashDir)s/ || true\n"
+                 "for x in `s3cmd ls -s --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch s3://%(b)s/%(linksPath)s/ | sed -e 's|.*s3://|s3://|'`; do"
                  "  mkdir -p '%(tarballLinkDir)s'; find '%(tarballLinkDir)s' -type l -delete;"
-                 "  ln -sf `s3cmd get -s --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch $x - 2>/dev/null` %(tarballLinkDir)s/`basename $x` || true\n"
+                 "  ln -sf `s3cmd get -s --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch $x -` %(tarballLinkDir)s/`basename $x` || true\n"
                  "done",
                  b=self.remoteStore,
                  storePath=spec["storePath"],
@@ -288,9 +288,9 @@ class S3RemoteSync:
                                 **spec)
     cmd = format("set -x; cd %(workdir)s && "
                  "TARSHA256=`sha256sum %(storePath)s/%(tarballNameWithRev)s | awk '{ print $1 }'` && "
-                 "s3cmd put -s -v --host s3.cern.ch --add-header \"x-amz-meta-sha256:$TARSHA256\" --host-bucket %(b)s.s3.cern.ch %(storePath)s/%(tarballNameWithRev)s s3://%(b)s/%(storePath)s/ 2>/dev/null || true\n"
+                 "s3cmd put -s -v --host s3.cern.ch --add-header \"x-amz-meta-sha256:$TARSHA256\" --host-bucket %(b)s.s3.cern.ch %(storePath)s/%(tarballNameWithRev)s s3://%(b)s/%(storePath)s/ || true\n"
                  "HASHEDURL=`readlink %(linksPath)s/%(tarballNameWithRev)s | sed -e's|^../../||'` &&"
-                 "echo $HASHEDURL | s3cmd put -s -v --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch --add-header=\"x-amz-website-redirect-location:https://s3.cern.ch/swift/v1/%(b)s/TARS/${HASHEDURL}\" - s3://%(b)s/%(linksPath)s/%(tarballNameWithRev)s 2>/dev/null || true\n",
+                 "echo $HASHEDURL | s3cmd put -s -v --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch --add-header=\"x-amz-website-redirect-location:https://s3.cern.ch/swift/v1/%(b)s/TARS/${HASHEDURL}\" - s3://%(b)s/%(linksPath)s/%(tarballNameWithRev)s || true\n",
                  workdir=self.workdir,
                  b=self.remoteStore,
                  storePath=spec["storePath"],

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -9,7 +9,8 @@ import subprocess
 BASH = "bash" if getstatusoutput("/bin/bash --version")[0] else "/bin/bash"
 
 def execute(command, printer=debug):
-  popen = subprocess.Popen(command, shell=is_string(command), stdout=subprocess.PIPE)
+  popen = subprocess.Popen(command, shell=is_string(command),
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
   lines_iterator = iter(popen.stdout.readline, "")
   for line in lines_iterator:
     if not line: break


### PR DESCRIPTION
This makes debugging problems with S3 uploads much easier.

This output is only shown when `--debug` is given.