### PR TITLE
HTTP backend: create dangling symlinks

### DIFF
--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -231,7 +231,7 @@ def finaliseArgs(args, parser, star):
     args.configDir = format(args.configDir, prefix="")
 
     # On selected platforms, caching is active by default
-    if args.architecture == "slc7_x86-64" and not args.preferSystem:
+    if args.architecture in ("slc7_x86-64", "ubuntu1804_x86-64") and not args.preferSystem:
       args.noSystem = True
       if not args.remoteStore:
         args.remoteStore = "https://s3.cern.ch/swift/v1/alibuild-repo"

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -185,7 +185,7 @@ class HttpRemoteSync:
       self.doneOrFailed.append(spec["hash"])
       return
 
-    execute(" ".join(("mkdir", "-p", spec["tarballHashDir"], spec["tarballLinkDir"])))
+    execute("mkdir -p %s %s" % (spec["tarballHashDir"], spec["tarballLinkDir"]))
     hashList = [x["name"] for x in hashList]
 
     hasErr = False


### PR DESCRIPTION
This is required so revision numbers don't conflict.

Adds a mode to `getRetry` to return the contents of a remote file, to make symlink creation easier.