### PR TITLE
If available, have architecture specific overrides

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -375,7 +375,7 @@ def doBuild(args, parser):
                     "Maybe you need to \"cd\" to the right directory or " +
                     "you forgot to run \"aliBuild init\"?") % (star(), args.configDir), 1)
 
-  defaultsReader = lambda : readDefaults(args.configDir, args.defaults, parser.error)
+  defaultsReader = lambda : readDefaults(args.configDir, args.defaults, parser.error, args.architecture)
   (err, overrides, taps) = parseDefaults(args.disable,
                                          defaultsReader, debug)
   dieOnError(err, err)

--- a/alibuild_helpers/deps.py
+++ b/alibuild_helpers/deps.py
@@ -20,7 +20,7 @@ def doDeps(args, parser):
 
   # Resolve all the package parsing boilerplate
   specs = {}
-  defaultsReader = lambda: readDefaults(args.configDir, args.defaults, parser.error)
+  defaultsReader = lambda: readDefaults(args.configDir, args.defaults, parser.error, args.architecture)
   (err, overrides, taps) = parseDefaults(args.disable, defaultsReader, debug)
   (systemPackages, ownPackages, failed, validDefaults) = \
     getPackageList(packages                = [args.package],

--- a/alibuild_helpers/doctor.py
+++ b/alibuild_helpers/doctor.py
@@ -159,7 +159,7 @@ def doDoctor(args, parser):
   specs = {}
   def unreachable():
     assert(False)
-  defaultsReader = lambda : readDefaults(args.configDir, args.defaults, parser.error)
+  defaultsReader = lambda : readDefaults(args.configDir, args.defaults, parser.error, args.architecture)
   (err, overrides, taps) = parseDefaults(args.disable, defaultsReader, info)
   if err:
     error(err)

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -51,7 +51,7 @@ def doInit(args):
   # Use standard functions supporting overrides and taps. Ignore all disables
   # and system packages as they are irrelevant in this context
   specs = {}
-  defaultsReader = lambda: readDefaults(args.configDir, args.defaults, error)
+  defaultsReader = lambda: readDefaults(args.configDir, args.defaults, error, args.architecture)
   (err, overrides, taps) = parseDefaults([], defaultsReader, debug)
   (_,_,_,validDefaults) = getPackageList(packages=[ p["name"] for p in pkgs ],
                                          specs=specs,

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -192,7 +192,7 @@ def readDefaults(configDir, defaults, error, architecture):
       error(err)
       sys.exit(1)
     for x in ["env", "disable", "overrides"]:
-      defaultsMeta.get(x, {}).update(archMeta.get(x, {}))
+      defaultsMeta.setdefault(x, {}).update(archMeta.get(x, {}))
     defaultsBody += "\n# Architecture defaults\n" + archBody
   return (defaultsMeta, defaultsBody)
 

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -171,7 +171,7 @@ def filterByArchitecture(arch, requires):
     if re.match(matcher, arch):
       yield require
 
-def readDefaults(configDir, defaults, error):
+def readDefaults(configDir, defaults, error, architecture):
   defaultsFilename = "%s/defaults-%s.sh" % (configDir, defaults)
   if not exists(defaultsFilename):
     viableDefaults = ["- " + basename(x).replace("defaults-","").replace(".sh", "")
@@ -183,6 +183,17 @@ def readDefaults(configDir, defaults, error):
   if err:
     error(err)
     sys.exit(1)
+  archDefaults = "%s/defaults-%s.sh" % (configDir, architecture)
+  archMeta = {}
+  archBody = ""
+  if exists(archDefaults):
+    err, archMeta, archBody = parseRecipe(getRecipeReader(defaultsFilename))
+    if err:
+      error(err)
+      sys.exit(1)
+    for x in ["env", "disable", "overrides"]:
+      defaultsMeta.get(x, {}).update(archMeta.get(x, {}))
+    defaultsBody += "\n# Architecture defaults\n" + archBody
   return (defaultsMeta, defaultsBody)
 
 # Get the appropriate recipe reader depending on th filename

--- a/docs/reference.markdown
+++ b/docs/reference.markdown
@@ -240,6 +240,19 @@ For a more complete example see
 You can limit which defaults can be applied to a given package by using the
 `valid_defaults` key.
 
+### Architecture defaults
+
+Architecture defaults are similar to normal defaults but they are
+always sourced, if available in alidist, and should never be provided on the
+command line. 
+
+Their filename is always:
+
+    defaults-<arch>.sh
+
+where `<arch>` is the current architecture. They have precedence over normal
+defaults.
+
 ## Relocation 
 
 aliBuild supports relocating binary packages so that the scratch space used for builds (e.g. /build) and the actual installation folder (i.e. /cvmfs/alice.cern.ch ) do not need to be the same. By design this is done automatically, and

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -67,7 +67,8 @@ class InitTestCase(unittest.TestCase):
         dist = fake_dist,
         defaults = "release",
         dryRun = True,
-        fetchRepos = False
+        fetchRepos = False,
+        architecture = "slc7_x86-64"
       )
       self.assertRaises(SystemExit, doInit, args)
       self.assertEqual(mock_info.mock_calls, [call('This will initialise local checkouts for zlib,AliRoot\n--dry-run / -n specified. Doing nothing.')])

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -102,7 +102,8 @@ class InitTestCase(unittest.TestCase):
         dist = fake_dist,
         defaults = "release",
         dryRun = False,
-        fetchRepos = False
+        fetchRepos = False,
+        architecture = "slc7_x86-64"
       )
       doInit(args)
       mock_execute.assert_called_with("git clone --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot")


### PR DESCRIPTION
This works in parallel of the usual "defaults" mechanism to override recipes on
a per architecture basis. For example to disable a given common package like
autotools or to force some compiler options which are specific for a given
architecture.