### PR TITLE
Strip trailing newlines from fake-symlink entries on S3

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -210,7 +210,7 @@ class HttpRemoteSync:
         linkTarget = self.getRetry("/".join((self.remoteStore, spec["linksPath"], pkg["name"])),
                                    returnResult=True)
         execute(format("ln -nsf %(target)s %(ld)s/%(n)s\n",
-                       target=linkTarget.decode("utf-8"),
+                       target=linkTarget.decode("utf-8").rstrip("\r\n"),
                        ld=spec["tarballLinkDir"],
                        n=pkg["name"]))
 


### PR DESCRIPTION
We want the symlinks created without the newline.

I've tested this in an SLC8 container, which has stray symlinks without this PR, and none with this PR.