### PR TITLE
Also restore leading ../../ for HTTPS remote

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -216,7 +216,7 @@ class HttpRemoteSync:
       else:
         linkTarget = self.getRetry("/".join((self.remoteStore, spec["linksPath"], pkg["name"])),
                                    returnResult=True, log=False)
-        execute(format("ln -nsf %(target)s %(ld)s/%(n)s\n",
+        execute(format("ln -nsf ../../%(target)s %(ld)s/%(n)s\n",
                        target=linkTarget.decode("utf-8").rstrip("\r\n"),
                        ld=spec["tarballLinkDir"],
                        n=pkg["name"]))


### PR DESCRIPTION
This prefix is removed in `S3RemoteStore.syncToRemote`, but needs to be restored here too, as the HTTPS remote is used to access S3 as well.

@ktf, I assume the HTTPS remote is *only* used to access S3. Is that right? If not, this might need to be handled specially.