### PR TITLE
Fix directory removal on Python 2

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -321,7 +321,7 @@ def createDistLinks(spec, specs, args, repoType, requiresType):
                   p=spec["package"],
                   v=spec["version"],
                   r=spec["revision"])
-  shutil.rmtree(target, True)
+  shutil.rmtree(target.encode("utf-8"), True)
   cmd = format("cd %(w)s && mkdir -p %(t)s", w=args.workDir, t=target)
   links = []
   for x in [spec["package"]] + list(spec[requiresType]):
@@ -893,7 +893,9 @@ def doBuild(args, parser):
     if fileHash != spec["hash"]:
       if fileHash != "0":
         debug("Mismatch between local area (%s) and the one which I should build (%s). Redoing." % (fileHash, spec["hash"]))
-      shutil.rmtree(dirname(hashFile), True)
+      # shutil.rmtree under Python 2 fails when hashFile is unicode and the
+      # directory contains files with non-ASCII names, e.g. Golang/Boost.
+      shutil.rmtree(dirname(hashFile).encode("utf-8"), True)
     else:
       # If we get here, we know we are in sync with whatever remote store.  We
       # can therefore create a directory which contains all the packages which


### PR DESCRIPTION
aliBuild fails with the following traceback on Ubuntu 18.04:

    Using cached build for golang
    Traceback (most recent call last):
      File "/usr/local/bin/aliBuild", line 132, in <module>
        doMain(args, parser)
      File "/usr/local/bin/aliBuild", line 82, in doMain
        printer, msg, code = doBuild(args, parser)
      File "/usr/local/lib/python2.7/dist-packages/alibuild_helpers/build.py", line 862, in doBuild
        shutil.rmtree(dirname(hashFile), True)
      File "/usr/lib/python2.7/shutil.py", line 270, in rmtree
        rmtree(fullname, ignore_errors, onerror)
      File "/usr/lib/python2.7/shutil.py", line 270, in rmtree
        rmtree(fullname, ignore_errors, onerror)
      File "/usr/lib/python2.7/shutil.py", line 270, in rmtree
        rmtree(fullname, ignore_errors, onerror)
      File "/usr/lib/python2.7/shutil.py", line 264, in rmtree
        fullname = os.path.join(path, name)
      File "/usr/lib/python2.7/posixpath.py", line 73, in join
        path += '/' + b
    UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1: ordinal not in range(128)
    ++ report_pr_errors --no-comments

This is because some packages create strangely-named test files:

    [root@alibuild04 sw]# find . -name $'*\xc3*'
    ./ubuntu1804_x86-64/golang/1.15.6-3/test/fixedbugs/issue27836.dir/Ämain.go
    ./ubuntu1804_x86-64/golang/1.15.6-3/test/fixedbugs/issue27836.dir/Äfoo.go
    ./ubuntu1804_x86-64/golang/1.15.6-2/test/fixedbugs/issue27836.dir/Ämain.go
    ./ubuntu1804_x86-64/golang/1.15.6-2/test/fixedbugs/issue27836.dir/Äfoo.go
    ./ubuntu1804_x86-64/golang/1.15.6-1/test/fixedbugs/issue27836.dir/Ämain.go
    ./ubuntu1804_x86-64/golang/1.15.6-1/test/fixedbugs/issue27836.dir/Äfoo.go
    ./SOURCES/boost/v1.74.0/v1.74.0/libs/wave/test/testwave/testfiles/utf8-test-ßµ™∃

This PR should fix that. This change also works under Python 3.