### PR TITLE
Use args of logging functions for lazy formatting

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -95,7 +95,7 @@ class HttpRemoteSync:
     for i in range(0, self.httpConnRetries):
       if i > 0:
         pauseSec = self.httpBackoff * (2 ** (i - 1))
-        debug("GET %s failed: retrying in %.2f" % (url, pauseSec))
+        debug("GET %s failed: retrying in %.2f", url, pauseSec)
         time.sleep(pauseSec)
         # If the download has failed, enable debug output, even if it was
         # disabled before. We disable debug output for e.g. symlink downloads
@@ -105,7 +105,7 @@ class HttpRemoteSync:
         log = True
       try:
         if log:
-          debug("GET %s: processing (attempt %d/%d)" % (url, i+1, self.httpConnRetries))
+          debug("GET %s: processing (attempt %d/%d)", url, i+1, self.httpConnRetries)
         if dest or returnResult:
           # Destination specified -- file (dest) or buffer (returnResult).
           # Use requests in stream mode
@@ -128,7 +128,7 @@ class HttpRemoteSync:
                 if downloaded == size:
                   debug("Download complete")
                 elif now - reportTime > 3:
-                  debug("%.0f%% downloaded..." % (100*downloaded/size))
+                  debug("%.0f%% downloaded...", 100*downloaded/size)
                   reportTime = now
           finally:
             if destFp:
@@ -162,7 +162,7 @@ class HttpRemoteSync:
             return resp.json()
       except (RequestException,ValueError,PartialDownloadError) as e:
         if i == self.httpConnRetries-1:
-          error("GET %s failed: %s" % (url, str(e)))
+          error("GET %s failed: %s", url, e)
         if dest:
           try:
             unlink(dest+".tmp")
@@ -172,10 +172,10 @@ class HttpRemoteSync:
 
   def syncToLocal(self, p, spec):
     if spec["hash"] in self.doneOrFailed:
-      debug("Will not redownload %s with build hash %s" % (p, spec["hash"]))
+      debug("Will not redownload %s with build hash %s", p, spec["hash"])
       return
 
-    debug("Updating remote store for package %s@%s" % (p, spec["hash"]))
+    debug("Updating remote store for package %s@%s", p, spec["hash"])
     hashListUrl = format("%(rs)s/%(sp)s/",
                         rs=self.remoteStore,
                         sp=spec["storePath"])
@@ -188,7 +188,7 @@ class HttpRemoteSync:
     if hashList is not None:
       pkgList = self.getRetry(pkgListUrl)
     if pkgList is None or hashList is None:
-      warning("%s (%s) not fetched: have you tried updating the recipes?" % (p, spec["hash"]))
+      warning("%s (%s) not fetched: have you tried updating the recipes?", p, spec["hash"])
       self.doneOrFailed.append(spec["hash"])
       return
 
@@ -237,7 +237,7 @@ class RsyncRemoteSync:
     self.workdir = workdir
 
   def syncToLocal(self, p, spec):
-    debug("Updating remote store for package %s@%s" % (p, spec["hash"]))
+    debug("Updating remote store for package %s@%s", p, spec["hash"])
     cmd = format("mkdir -p %(tarballHashDir)s\n"
                  "rsync -av %(ro)s %(remoteStore)s/%(storePath)s/ %(tarballHashDir)s/ || true\n"
                  "rsync -av --delete %(ro)s %(remoteStore)s/%(linksPath)s/ %(tarballLinkDir)s/ || true\n",
@@ -278,7 +278,7 @@ class S3RemoteSync:
     self.workdir = workdir
 
   def syncToLocal(self, p, spec):
-    debug("Updating remote store for package %s@%s" % (p, spec["hash"]))
+    debug("Updating remote store for package %s@%s", p, spec["hash"])
     cmd = format(
                  "s3cmd --no-check-md5 sync -s -v --host s3.cern.ch --host-bucket %(b)s.s3.cern.ch s3://%(b)s/%(storePath)s/ %(tarballHashDir)s/ 2>&1 || true\n"
                  "mkdir -p '%(tarballLinkDir)s'; find '%(tarballLinkDir)s' -type l -delete;\n"
@@ -405,14 +405,11 @@ def doBuild(args, parser):
 
   os.environ["ALIBUILD_ALIDIST_HASH"] = getDirectoryHash(args.configDir)
 
-  debug("Building for architecture %s" % args.architecture)
-  debug("Number of parallel builds: %d" % args.jobs)
-  debug(format("Using %(star)sBuild from "
-               "%(star)sbuild@%(toolHash)s recipes "
-               "in %(star)sdist@%(distHash)s",
-               star=star(),
-               toolHash=getDirectoryHash(dirname(__file__)),
-               distHash=os.environ["ALIBUILD_ALIDIST_HASH"]))
+  debug("Building for architecture %s", args.architecture)
+  debug("Number of parallel builds: %d", args.jobs)
+  debug("Using %sBuild from %sbuild@%s recipes in %sdist@%s",
+        star(), star(), getDirectoryHash(dirname(__file__)), star(),
+        os.environ["ALIBUILD_ALIDIST_HASH"])
 
   (systemPackages, ownPackages, failed, validDefaults) = getPackageList(packages                = packages,
                                                                         specs                   = specs,
@@ -444,10 +441,10 @@ def doBuild(args, parser):
     x["runtime_requires"] = [r for r in x["runtime_requires"] if not r in args.disable]
 
   if systemPackages:
-    banner("%sBuild can take the following packages from the system and will not build them:\n  %s" %
-           (star(), ", ".join(systemPackages)))
+    banner("%sBuild can take the following packages from the system and will not build them:\n  %s",
+           star(), ", ".join(systemPackages))
   if ownPackages:
-    banner("The following packages cannot be taken from the system and will be built:\n  %s" %
+    banner("The following packages cannot be taken from the system and will be built:\n  %s",
            ", ".join(ownPackages))
 
   # Do topological sort to have the correct build order even in the
@@ -489,17 +486,18 @@ def doBuild(args, parser):
                           pkgs=", ".join(set(x.strip() for (x,y) in develPkgsUpper) - set(develPkgs))), 1)
 
   if buildOrder:
-    banner("Packages will be built in the following order:\n - %s" %
-           "\n - ".join([ x+" (development package)" if x in develPkgs else "%s@%s" % (x, specs[x]["tag"]) for x in buildOrder if x != "defaults-release" ]))
+    banner("Packages will be built in the following order:\n - %s",
+           "\n - ".join(x+" (development package)" if x in develPkgs else "%s@%s" % (x, specs[x]["tag"])
+                        for x in buildOrder if x != "defaults-release"))
 
   if develPkgs:
-    banner(format("You have packages in development mode.\n"
-                  "This means their source code can be freely modified under:\n\n"
-                  "  %(pwd)s/<package_name>\n\n"
-                  "%(star)sBuild does not automatically update such packages to avoid work loss.\n"
-                  "In most cases this is achieved by doing in the package source directory:\n\n"
-                  "  git pull --rebase\n",
-                  pwd=os.getcwd(), star=star()))
+    banner("You have packages in development mode.\n"
+           "This means their source code can be freely modified under:\n\n"
+           "  %s/<package_name>\n\n"
+           "%sBuild does not automatically update such packages to avoid work loss.\n"
+           "In most cases this is achieved by doing in the package source directory:\n\n"
+           "  git pull --rebase\n",
+           os.getcwd(), star())
 
   # Clone/update repos
   import concurrent.futures
@@ -512,7 +510,7 @@ def doBuild(args, parser):
       if specs[p]["package"] in develPkgs:
          specs[p]["source"] = join(os.getcwd(), specs[p]["package"])
          cmd = "git ls-remote --heads %s" % specs[p]["source"]
-      debug("Executing %s" % cmd)
+      debug("Executing %s", cmd)
       err, output = getStatusOutputBash(cmd)
       if err:
         raise RuntimeError("Error on '%s': %s" % (cmd, output))
@@ -526,7 +524,7 @@ def doBuild(args, parser):
         except Exception as exc:
             raise RuntimeError("Error on fetching '%r'. Aborting." % futurePackage)
         else:
-            debug('%r package updated: %s' % (futurePackage, data))
+            debug("%r package updated: %s", futurePackage, data)
 
   # Resolve the tag to the actual commit ref
   for p in buildOrder:
@@ -555,7 +553,7 @@ def doBuild(args, parser):
             cmd = "cd %s && git diff -r HEAD && git status --porcelain" % spec["source"]
             h = Hasher()
             err = execute(cmd, h)
-            debug(err, cmd)
+            debug("Command %s returned %d", cmd, err)
             dieOnError(err, "Unable to detect source code changes.")
             spec["devel_hash"] = spec["commit_hash"] + h.hexdigest()
             cmd = "cd %s && git rev-parse --abbrev-ref HEAD" % spec["source"]
@@ -599,7 +597,7 @@ def doBuild(args, parser):
   mainPackage = buildOrder[-1]
   mainHash = specs[mainPackage]["commit_hash"]
 
-  debug("Main package is %s@%s" % (mainPackage, mainHash))
+  debug("Main package is %s@%s", mainPackage, mainHash)
   if args.debug:
     logger_handler.setFormatter(
         LogFormatter("%%(asctime)s:%%(levelname)s:%s:%s: %%(message)s" %
@@ -611,7 +609,7 @@ def doBuild(args, parser):
   for p in buildOrder:
     spec = specs[p]
     if "source" in spec:
-      debug("Commit hash for %s@%s is %s" % (spec["source"], spec["tag"], spec["commit_hash"]))
+      debug("Commit hash for %s@%s is %s", spec["source"], spec["tag"], spec["commit_hash"])
 
   # Calculate the hashes. We do this in build order so that we can guarantee
   # that the hashes of the dependencies are calculated first.  Also notice that
@@ -621,8 +619,8 @@ def doBuild(args, parser):
   debug("Calculating hashes.")
   for p in buildOrder:
     spec = specs[p]
-    debug(spec)
-    debug(develPkgs)
+    debug("spec = %r", spec)
+    debug("develPkgs = %r", develPkgs)
     h = Hasher()
     dh = Hasher()
     for x in ["recipe", "version", "package", "commit_hash",
@@ -652,7 +650,7 @@ def doBuild(args, parser):
         h("relocate:"+" ".join(sorted(spec["relocate_paths"])))
     spec["hash"] = h.hexdigest()
     spec["deps_hash"] = dh.hexdigest()
-    debug("Hash for recipe %s is %s" % (p, spec["hash"]))
+    debug("Hash for recipe %s is %s", p, spec["hash"])
 
   # This adds to the spec where it should find, locally or remotely the
   # various tarballs and links.
@@ -700,7 +698,7 @@ def doBuild(args, parser):
     # a build_requires only anymore, so we drop it from the list.
     spec["full_build_requires"] = set(spec["full_build_requires"]) - spec["full_runtime_requires"]
 
-  debug("We will build packages in the following order: %s" % " ".join(buildOrder))
+  debug("We will build packages in the following order: %s", " ".join(buildOrder))
   if args.dryRun:
     return (info, "--dry-run / -n specified. Not building.", 0)
 
@@ -730,7 +728,7 @@ def doBuild(args, parser):
           LogFormatter("%%(asctime)s:%%(levelname)s:%s:%s:%s: %%(message)s" %
                        (mainPackage, p, args.develPrefix if "develPrefix" in args else mainHash[0:8])))
     if spec["package"] in develPkgs and getattr(syncHelper, "writeStore", None):
-      warning("Disabling remote write store from now since %s is a development package." % spec["package"])
+      warning("Disabling remote write store from now since %s is a development package.", spec["package"])
       syncHelper.writeStore = ""
 
     # Since we can execute this multiple times for a given package, in order to
@@ -763,13 +761,13 @@ def doBuild(args, parser):
                        a=args.architecture,
                        p=spec["package"],
                        v=spec["version"])
-    debug("Glob pattern used: %s" % linksGlob)
+    debug("Glob pattern used: %s", linksGlob)
     packages = glob(linksGlob)
     # In case there is no installed software, revision is 1
     # If there is already an installed package:
     # - Remove it if we do not know its hash
     # - Use the latest number in the version, to decide its revision
-    debug("Packages already built using this version\n%s" % "\n".join(packages))
+    debug("Packages already built using this version\n%s", "\n".join(packages))
     busyRevisions = []
 
     # Calculate the build_family for the package
@@ -813,7 +811,7 @@ def doBuild(args, parser):
         if spec["package"] in develPkgs and "incremental_recipe" in spec:
           spec["obsolete_tarball"] = d
         else:
-          debug("Package %s with hash %s is already found in %s. Not building." % (p, h, d))
+          debug("Package %s with hash %s is already found in %s. Not building.", p, h, d)
           src = format("%(v)s-%(r)s",
                        w=workDir,
                        v=spec["version"],
@@ -830,7 +828,7 @@ def doBuild(args, parser):
 
           getstatusoutput("ln -snf %s %s" % (src, dst1))
           getstatusoutput("ln -snf %s %s" % (src, dst2))
-          info("Using cached build for %s" % p)
+          info("Using cached build for %s", p)
         break
       else:
         busyRevisions.append(revision)
@@ -842,7 +840,7 @@ def doBuild(args, parser):
 
     # Recreate symlinks to this development package builds.
     if spec["package"] in develPkgs:
-      debug("Creating symlinks to builds of devel package %s" % spec["package"])
+      debug("Creating symlinks to builds of devel package %s", spec["package"])
       cmd = format("ln -snf %(pkgHash)s %(wd)s/BUILD/%(pkgName)s-latest",
                    wd=workDir,
                    pkgName=spec["package"],
@@ -854,7 +852,7 @@ def doBuild(args, parser):
                       pkgHash=spec["hash"],
                       devPrefix=develPrefix)
       err = execute(cmd)
-      debug(err, cmd)
+      debug("Command %s returned %d", cmd, err)
       # Last package built gets a "latest" mark.
       cmd = format("ln -snf %(pkgVersion)s-%(pkgRevision)s %(wd)s/%(arch)s/%(pkgName)s/latest",
                    wd=workDir,
@@ -872,13 +870,13 @@ def doBuild(args, parser):
                       pkgRevision=spec["revision"],
                       family=spec["build_family"])
       err = execute(cmd)
-      debug(err, cmd)
+      debug("Command %s returned %d", cmd, err)
 
     # Check if this development package needs to be rebuilt.
     if spec["package"] in develPkgs:
-      debug("Checking if devel package %s needs rebuild" % spec["package"])
+      debug("Checking if devel package %s needs rebuild", spec["package"])
       if spec["devel_hash"]+spec["deps_hash"] == spec["old_devel_hash"]:
-        info("Development package %s does not need rebuild" % spec["package"])
+        info("Development package %s does not need rebuild", spec["package"])
         buildOrder.pop(0)
         continue
 
@@ -892,7 +890,8 @@ def doBuild(args, parser):
     fileHash = readHashFile(hashFile)
     if fileHash != spec["hash"]:
       if fileHash != "0":
-        debug("Mismatch between local area (%s) and the one which I should build (%s). Redoing." % (fileHash, spec["hash"]))
+        debug("Mismatch between local area (%s) and the one which I should build (%s). Redoing.",
+              fileHash, spec["hash"])
       # shutil.rmtree under Python 2 fails when hashFile is unicode and the
       # directory contains files with non-ASCII names, e.g. Golang/Boost.
       shutil.rmtree(dirname(hashFile).encode("utf-8"), True)
@@ -900,7 +899,7 @@ def doBuild(args, parser):
       # If we get here, we know we are in sync with whatever remote store.  We
       # can therefore create a directory which contains all the packages which
       # were used to compile this one.
-      debug("Package %s was correctly compiled. Moving to next one." % spec["package"])
+      debug("Package %s was correctly compiled. Moving to next one.", spec["package"])
       # If using incremental builds, next time we execute the script we need to remove
       # the placeholders which avoid rebuilds.
       if spec["package"] in develPkgs and "incremental_recipe" in spec:
@@ -930,7 +929,7 @@ def doBuild(args, parser):
           cleanupDirs.append(format("%(w)s/SOURCES/%(p)s",
                                     w=workDir,
                                     p=spec["package"]))
-        debug("Cleaning up:\n" + "\n".join(cleanupDirs))
+        debug("Cleaning up:\n%s", "\n".join(cleanupDirs))
 
         for d in cleanupDirs:
           shutil.rmtree(d.encode("utf8"), True)
@@ -951,19 +950,16 @@ def doBuild(args, parser):
           pass
       continue
 
-    debug("Looking for cached tarball in %s" % spec["tarballHashDir"])
+    debug("Looking for cached tarball in %s", spec["tarballHashDir"])
     # FIXME: I should get the tarballHashDir updated with server at this point.
     #        It does not really matter that the symlinks are ok at this point
     #        as I only used the tarballs as reusable binary blobs.
     spec["cachedTarball"] = ""
     if not spec["package"] in develPkgs:
-      tarballs = [x
-                  for x in glob("%s/*" % spec["tarballHashDir"])
-                  if x.endswith("gz")]
+      tarballs = glob(join(spec["tarballHashDir"], "*gz"))
       spec["cachedTarball"] = tarballs[0] if len(tarballs) else ""
-      debug(spec["cachedTarball"] and
-            "Found tarball in %s" % spec["cachedTarball"] or
-            "No cache tarballs found")
+      debug("Found tarball in %s" % spec["cachedTarball"]
+            if spec["cachedTarball"] else "No cache tarballs found")
 
     # Generate the part which sources the environment for all the dependencies.
     # Notice that we guarantee that a dependency is always sourced before the
@@ -1036,7 +1032,7 @@ def doBuild(args, parser):
     if partialCloneFilter and not args.docker:
       partialCloneStatement = "export GIT_PARTIAL_CLONE_FILTER='--filter=blob:none'"
 
-    debug(spec)
+    debug("spec = %r", spec)
 
     cmd_raw = ""
     try:
@@ -1092,9 +1088,9 @@ def doBuild(args, parser):
     writeAll("%s/build.sh" % scriptDir, cmd)
     writeAll("%s/%s.sh" % (scriptDir, spec["package"]), spec["recipe"])
 
-    banner("Building %s@%s" % (spec["package"],
-                               args.develPrefix if "develPrefix" in args and spec["package"]  in develPkgs
-                                                else spec["version"]))
+    banner("Building %s@%s", spec["package"],
+           args.develPrefix if "develPrefix" in args and spec["package"] in develPkgs
+           else spec["version"])
     # Define the environment so that it can be passed up to the
     # actual build script
     buildEnvironment = [
@@ -1165,7 +1161,7 @@ def doBuild(args, parser):
               mirrorVolume=mirrorVolume,
               overrideSource=overrideSource,
               scriptDir=scriptDir)
-      debug(dockerWrapper)
+      debug("Docker command: %s", dockerWrapper)
       err = execute(dockerWrapper)
     else:
       progress = ProgressPrint("%s is being built (use --debug for full output)" % spec["package"])
@@ -1210,20 +1206,16 @@ def doBuild(args, parser):
     dieOnError(err, buildErrMsg)
 
     syncHelper.syncToRemote(p, spec)
-  banner(format("Build of %(mainPackage)s successfully completed on `%(h)s'.\n"
-              "Your software installation is at:"
-              "\n\n  %(wp)s\n\n"
-              "You can use this package by loading the environment:"
-              "\n\n  alienv enter %(mainPackage)s/latest-%(buildFamily)s",
-              mainPackage=mainPackage,
-              buildFamily=mainBuildFamily,
-              h=socket.gethostname(),
-              defaults=args.defaults,
-              wp=abspath(join(args.workDir, args.architecture))))
+  banner("Build of %s successfully completed on `%s'.\n"
+         "Your software installation is at:"
+         "\n\n  %s\n\n"
+         "You can use this package by loading the environment:"
+         "\n\n  alienv enter %s/latest-%s",
+         mainPackage, socket.gethostname(),
+         abspath(join(args.workDir, args.architecture)),
+         mainPackage, mainBuildFamily)
   for x in develPkgs:
-    banner(format("Build directory for devel package %(p)s:\n%(w)s/BUILD/%(p)s-latest%(devSuffix)s/%(p)s",
-                  p=x,
-                  devSuffix="-"+args.develPrefix if "develPrefix" in args else "",
-                  w=abspath(args.workDir)))
+    banner("Build directory for devel package %s:\n%s/BUILD/%s-latest%s/%s",
+           x, abspath(args.workDir), x, "-"+args.develPrefix if "develPrefix" in args else "", x)
   return (debug, "Everything done", 0)
 

--- a/alibuild_helpers/deps.py
+++ b/alibuild_helpers/deps.py
@@ -99,8 +99,7 @@ def doDeps(args, parser):
               dotFile=fp.name))
     execute(["dot", fp.name, "-Tpdf", "-o", args.outgraph])
   except Exception as e:
-    error(format("Error generating dependencies with dot: %(type)s: %(msg)s",
-                 type=type(e).__name__, msg=str(e)))
+    error("Error generating dependencies with dot: %s: %s", type(e).__name__, e)
   else:
     info("Dependencies graph generated: %s" % args.outgraph)
   if fp.name != args.outdot:

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -26,25 +26,25 @@ def doInit(args):
   assert(type(pkgs) == list)
   if args.dryRun:
     info("This will initialise local checkouts for %s\n"
-         "--dry-run / -n specified. Doing nothing." % ",".join(x["name"] for x in pkgs))
+         "--dry-run / -n specified. Doing nothing.", ",".join(x["name"] for x in pkgs))
     sys.exit(0)
   try:
     path.exists(args.develPrefix) or os.mkdir(args.develPrefix)
     path.exists(args.referenceSources) or os.makedirs(args.referenceSources)
   except OSError as e:
-    error(str(e))
+    error("%s", e)
     sys.exit(1)
 
   # Fetch recipes first if necessary
   if path.exists(args.configDir):
-    warning("using existing recipes from %s" % args.configDir)
+    warning("using existing recipes from %s", args.configDir)
   else:
     cmd = format("git clone %(pcf)s %(repo)s%(branch)s %(cd)s",
                  pcf=partialCloneFilter,
                  repo=args.dist["repo"] if ":" in args.dist["repo"] else "https://github.com/%s" % args.dist["repo"],
                  branch=" -b "+args.dist["ver"] if args.dist["ver"] else "",
                  cd=args.configDir)
-    debug(cmd)
+    debug("%s", cmd)
     err = execute(cmd)
     dieOnError(err!=0, "cannot clone recipes")
 
@@ -80,10 +80,10 @@ def doInit(args):
     writeRepo = spec.get("write_repo", spec.get("source"))
     dieOnError(not writeRepo, "package %s has no source field and cannot be developed" % spec["package"])
     if path.exists(dest):
-      warning("not cloning %s since it already exists" % spec["package"])
+      warning("not cloning %s since it already exists", spec["package"])
       continue
     p["ver"] = p["ver"] if p["ver"] else spec.get("tag", spec["version"])
-    debug("cloning %s%s for development" % (spec["package"], " version "+p["ver"] if p["ver"] else ""))
+    debug("cloning %s%s for development", spec["package"], " version "+p["ver"] if p["ver"] else "")
 
     updateReferenceRepoSpec(args.referenceSources, spec["package"], spec, True)
     cmd = format("git clone %(pcf)s %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
@@ -94,7 +94,7 @@ def doInit(args):
                  branch=" -b "+p["ver"] if p["ver"] else "",
                  refSource=join(args.referenceSources, spec["package"].lower()),
                  cd=dest)
-    debug(cmd)
+    debug("%s", cmd)
     err = execute(cmd)
     dieOnError(err!=0, "cannot clone %s%s" %
                        (spec["package"], " version "+p["ver"] if p["ver"] else ""))
@@ -109,6 +109,5 @@ def doInit(args):
       with open(repoAltConf, "w") as fil:
         fil.write(os.path.relpath(refObjects, repoObjects) + "\n")
 
-  banner(format("Development directory %(d)s created%(pkgs)s",
-         pkgs=" for "+", ".join([ x["name"].lower() for x in pkgs ]) if pkgs else "",
-         d=args.develPrefix))
+  banner("Development directory %s created%s", args.develPrefix,
+         " for "+", ".join(x["name"].lower() for x in pkgs) if pkgs else "")

--- a/alibuild_helpers/log.py
+++ b/alibuild_helpers/log.py
@@ -10,7 +10,7 @@ debug, error, warning, info, success = (None, None, None, None, None)
 
 def dieOnError(err, msg):
   if err:
-    error(msg)
+    error("%s", msg)
     sys.exit(1)
 
 class LogFormatter(logging.Formatter):
@@ -22,7 +22,7 @@ class LogFormatter(logging.Formatter):
                           logging.CRITICAL: "\033[1;37;41m",
                           logging.SUCCESS:  "\033[1;32m" } if sys.stdout.isatty() else {}
   def format(self, record):
-    record.msg = to_unicode(record.msg)
+    record.msg = to_unicode(record.msg % record.args)
     if record.levelno == logging.BANNER and sys.stdout.isatty():
       lines = record.msg.split("\n")
       return "\n\033[1;34m==>\033[m \033[1m%s\033[m" % lines[0] + \

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -179,12 +179,11 @@ def readDefaults(configDir, defaults, error, architecture):
   if not exists(defaultsFilename):
     viableDefaults = ["- " + basename(x).replace("defaults-","").replace(".sh", "")
                       for x in glob("%s/defaults-*.sh" % configDir)]
-    error(format("Default `%(d)s' does not exists. Viable options:\n%(v)s",
-                 d=defaults or "<no defaults specified>",
-                 v="\n".join(viableDefaults)))
+    error("Default `%s' does not exists. Viable options:\n%s",
+          defaults or "<no defaults specified>", "\n".join(viableDefaults))
   err, defaultsMeta, defaultsBody = parseRecipe(getRecipeReader(defaultsFilename))
   if err:
-    error(err)
+    error("%s", err)
     sys.exit(1)
   archDefaults = "%s/defaults-%s.sh" % (configDir, architecture)
   archMeta = {}
@@ -192,7 +191,7 @@ def readDefaults(configDir, defaults, error, architecture):
   if exists(archDefaults):
     err, archMeta, archBody = parseRecipe(getRecipeReader(defaultsFilename))
     if err:
-      error(err)
+      error("%s", err)
       sys.exit(1)
     for x in ["env", "disable", "overrides"]:
       defaultsMeta.setdefault(x, {}).update(archMeta.get(x, {}))
@@ -286,7 +285,7 @@ def parseDefaults(disable, defaultsGetter, log):
   # metadata early and extract the override and disable data.
   defaultsDisable = asList(defaultsMeta.get("disable", []))
   for x in defaultsDisable:
-    log("Package %s has been disabled by current default." % x)
+    log("Package %s has been disabled by current default.", x)
   disable.extend(defaultsDisable)
   if type(defaultsMeta.get("overrides", OrderedDict())) != OrderedDict:
     return ("overrides should be a dictionary", None, None)
@@ -328,7 +327,7 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
     for override in overrides:
       if not re.match("^" + override.strip("^$") + "$", lowerPkg):
         continue
-      log("Overrides for package %s: %s" % (spec["package"], overrides[override]))
+      log("Overrides for package %s: %s", spec["package"], overrides[override])
       spec.update(overrides.get(override, {}) or {})
 
     # If --always-prefer-system is passed or if prefer_system is set to true

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -61,10 +61,10 @@ def updateReferenceRepo(referenceSources, p, spec, fetch=True, usePartialClone=T
 
   if not is_writeable(referenceSources):
     if path.exists(referenceRepo):
-      debug("Using %s as reference for %s" % (referenceRepo, p))
+      debug("Using %s as reference for %s", referenceRepo, p)
       return referenceRepo  # reference is read-only
     else:
-      debug("Cannot create reference for %s in %s" % (p, referenceSources))
+      debug("Cannot create reference for %s in %s", p, referenceSources)
       return None  # no reference can be found and created (not fatal)
 
   err = False
@@ -72,7 +72,7 @@ def updateReferenceRepo(referenceSources, p, spec, fetch=True, usePartialClone=T
   if not path.exists(referenceRepo):
     cmd = ["git", "clone"] + (usePartialClone and [partialCloneFilter] or []) + ["--bare", spec["source"], referenceRepo]
     cmd = [x for x in cmd if x]
-    debug("Cloning reference repository: %s" % " ".join(cmd))
+    debug("Cloning reference repository: %s", " ".join(cmd))
     err = execute(cmd)
   elif fetch:
     cmd = format("cd %(referenceRepo)s && "
@@ -81,7 +81,7 @@ def updateReferenceRepo(referenceSources, p, spec, fetch=True, usePartialClone=T
                  referenceRepo=referenceRepo,
                  source=spec["source"],
                  logPath=logPath)
-    debug("Updating reference repository: %s" % cmd)
+    debug("Updating reference repository: %s", cmd)
     err = execute(cmd)
   if os.path.exists(logPath):
     execute("cat " + logPath)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -190,9 +190,9 @@ class BuildTestCase(unittest.TestCase):
         "/sw/TARS/osx_x86-64/defaults-release/defaults-release-v1-*.osx_x86-64.tar.gz": ["/sw/TARS/osx_x86-64/defaults-release/defaults-release-v1-1.osx_x86-64.tar.gz"],
         "/sw/TARS/osx_x86-64/zlib/zlib-v1.2.3-*.osx_x86-64.tar.gz": [],
         "/sw/TARS/osx_x86-64/ROOT/ROOT-v6-08-30-*.osx_x86-64.tar.gz": [],
-        "/sw/TARS/osx_x86-64/store/27/27ce49698e818e8efb56b6eff6dd785e503df341/*": [],
-        "/sw/TARS/osx_x86-64/store/3e/3e90b4e08bad439fa5f25282480d1adb9efb0c0d/*": [],
-        "/sw/TARS/osx_x86-64/store/%s/%s/*" % (TEST_ROOT_BUILD_HASH[0:2], TEST_ROOT_BUILD_HASH): [],
+        "/sw/TARS/osx_x86-64/store/27/27ce49698e818e8efb56b6eff6dd785e503df341/*gz": [],
+        "/sw/TARS/osx_x86-64/store/3e/3e90b4e08bad439fa5f25282480d1adb9efb0c0d/*gz": [],
+        "/sw/TARS/osx_x86-64/store/%s/%s/*gz" % (TEST_ROOT_BUILD_HASH[0:2], TEST_ROOT_BUILD_HASH): [],
         "/sw/TARS/osx_x86-64/defaults-release/defaults-release-v1-1.osx_x86-64.tar.gz": ["../../osx_x86-64/store/27/27ce49698e818e8efb56b6eff6dd785e503df341/defaults-release-v1-1.osx_x86-64.tar.gz"],
       }[x]
     os.environ["ALIBUILD_NO_ANALYTICS"] = "1"

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -76,9 +76,9 @@ class DoctorTestCase(unittest.TestCase):
     # Collect printouts
     def resetOut():
       return { "warning": StringIO(), "error": StringIO(), "banner": StringIO() }
-    mockPrintError.side_effect   = lambda e: out["error"].write(e+"\n")
-    mockPrintWarning.side_effect = lambda e: out["warning"].write(e+"\n")
-    mockPrintBanner.side_effect  = lambda e: out["banner"].write(e+"\n")
+    mockPrintError.side_effect   = lambda e, *a: out["error"].write((e%a)+"\n")
+    mockPrintWarning.side_effect = lambda e, *a: out["warning"].write((e%a)+"\n")
+    mockPrintBanner.side_effect  = lambda e, *a: out["banner"].write((e%a)+"\n")
 
     args = Namespace(workDir="/work",
                      configDir="/dist",

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -71,7 +71,7 @@ class InitTestCase(unittest.TestCase):
         architecture = "slc7_x86-64"
       )
       self.assertRaises(SystemExit, doInit, args)
-      self.assertEqual(mock_info.mock_calls, [call('This will initialise local checkouts for zlib,AliRoot\n--dry-run / -n specified. Doing nothing.')])
+      self.assertEqual(mock_info.mock_calls, [call('This will initialise local checkouts for %s\n--dry-run / -n specified. Doing nothing.', 'zlib,AliRoot')])
 
     @mock.patch("alibuild_helpers.init.banner")
     @mock.patch("alibuild_helpers.init.info")

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -18,7 +18,7 @@ class LogTestCase(unittest.TestCase):
     def test_dieOnError(self, mock_sys, mock_error):
       dieOnError(True, "Message")
       mock_sys.exit.assert_called_once_with(1)
-      mock_error.assert_called_once_with("Message")
+      mock_error.assert_called_once_with("%s", "Message")
       mock_error.reset_mock()
       dieOnError(False, "Message")
       mock_error.assert_not_called()

--- a/tests/test_parseRecipe.py
+++ b/tests/test_parseRecipe.py
@@ -57,8 +57,8 @@ found unexpected end of stream
 class Recoder(object):
   def __init__(self):
     self.buffer = ""
-  def __call__(self, s):
-    self.buffer += s
+  def __call__(self, s, *a):
+    self.buffer += s % a
 
 class BufferReader(object):
   def __init__(self, filename, recipe):


### PR DESCRIPTION
Logging functions (like `debug`, `info`, `error`) can take extra arguments, which are substituted into the message using printf-like syntax (`%s` and the like). This formatting is only done if the given logging level is actually enabled, giving some minor speed up in case debug logging is disabled. It also makes the code cleaner, as e.g. `debug(format("%s %s", a, b))` can be written as `debug("%s %s", a, b)` instead.

This patch also updates unit tests to work with the built-in logging convention.

Also includes fixes for the minor problem where `err = execute(cmd); debug(err, cmd)` would not output `cmd`; only `err` (the exit code) without explanation. I've changed this to output both `cmd` and `err` with a more descriptive message.

Tested and working.