### PR TITLE
Separate local-only builds from remote revisions

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -67,6 +67,7 @@ def getDirectoryHash(d):
 
 # Helper class which does not do anything to sync
 class NoRemoteSync:
+  writeStore = ""
   def syncToLocal(self, p, spec):
     pass
   def syncToRemote(self, p, spec):
@@ -727,7 +728,7 @@ def doBuild(args, parser):
       logger_handler.setFormatter(
           LogFormatter("%%(asctime)s:%%(levelname)s:%s:%s:%s: %%(message)s" %
                        (mainPackage, p, args.develPrefix if "develPrefix" in args else mainHash[0:8])))
-    if spec["package"] in develPkgs and getattr(syncHelper, "writeStore", None):
+    if spec["package"] in develPkgs and syncHelper.writeStore:
       warning("Disabling remote write store from now since %s is a development package.", spec["package"])
       syncHelper.writeStore = ""
 
@@ -768,7 +769,6 @@ def doBuild(args, parser):
     # - Remove it if we do not know its hash
     # - Use the latest number in the version, to decide its revision
     debug("Packages already built using this version\n%s", "\n".join(packages))
-    busyRevisions = []
 
     # Calculate the build_family for the package
     #
@@ -792,51 +792,53 @@ def doBuild(args, parser):
     if spec["package"] == mainPackage:
       mainBuildFamily = spec["build_family"]
 
+    busyRevisions = set()
+    # We can tell that the remote store is read-only if it has an empty or
+    # no writeStore property. See below for explanation of why we need this.
+    revisionPrefix = "" if syncHelper.writeStore else "local"
     for d in packages:
-      realPath = readlink(d)
-      matcher = format("../../%(a)s/store/[0-9a-f]{2}/([0-9a-f]*)/%(p)s-%(v)s-([0-9]*).%(a)s.tar.gz$",
-                       a=args.architecture,
-                       p=spec["package"],
-                       v=spec["version"])
-      m = re.match(matcher, realPath)
-      if not m:
+      match = re.match(
+        "../../%s/store/[0-9a-f]{2}/([0-9a-f]+)/%s-%s-(%s[0-9]+).%s.tar.gz$" %
+        tuple(map(re.escape, (args.architecture, spec["package"], spec["version"],
+                              revisionPrefix, args.architecture))),
+        readlink(d))
+      if not match:
         continue
-      h, revision = m.groups()
-      revision = int(revision)
+      h, revision = match.groups()
+      if h != spec["hash"]:
+        # Strip revisionPrefix; the rest is an integer. Convert it to an int
+        # so we can get a sensible max() existing revision below.
+        busyRevisions.add(int(revision[len(revisionPrefix):]))
+        continue
 
       # If we have an hash match, we use the old revision for the package
       # and we do not need to build it.
-      if h == spec["hash"]:
-        spec["revision"] = revision
-        if spec["package"] in develPkgs and "incremental_recipe" in spec:
-          spec["obsolete_tarball"] = d
-        else:
-          debug("Package %s with hash %s is already found in %s. Not building.", p, h, d)
-          src = format("%(v)s-%(r)s",
-                       w=workDir,
-                       v=spec["version"],
-                       r=spec["revision"])
-          dst1 = format("%(w)s/%(a)s/%(p)s/latest-%(bf)s",
-                        w=workDir,
-                        a=args.architecture,
-                        p=spec["package"],
-                        bf=spec["build_family"])
-          dst2 = format("%(w)s/%(a)s/%(p)s/latest",
-                        w=workDir,
-                        a=args.architecture,
-                        p=spec["package"])
-
-          getstatusoutput("ln -snf %s %s" % (src, dst1))
-          getstatusoutput("ln -snf %s %s" % (src, dst2))
-          info("Using cached build for %s", p)
-        break
+      spec["revision"] = revision
+      if spec["package"] in develPkgs and "incremental_recipe" in spec:
+        spec["obsolete_tarball"] = d
       else:
-        busyRevisions.append(revision)
+        debug("Package %s with hash %s is already found in %s. Not building.",
+              p, h, d)
+        getstatusoutput("ln -snf %s-%s %s/%s/%s/latest-%s" % (
+          spec["version"], spec["revision"],
+          workDir, args.architecture, spec["package"], spec["build_family"]))
+        getstatusoutput("ln -snf %s-%s %s/%s/%s/latest" % (
+          spec["version"], spec["revision"],
+          workDir, args.architecture, spec["package"]))
+        info("Using cached build for %s", p)
+      break
 
-    if not "revision" in spec and busyRevisions:
-      spec["revision"] = min(set(range(1, max(busyRevisions)+2)) - set(busyRevisions))
-    elif not "revision" in spec:
-      spec["revision"] = "1"
+    # If we aren't using an existing revision, assign the next free revision
+    # to this package. If we're not uploading it, name it localN to avoid
+    # interference with the remote store -- in case this package is built
+    # somewhere else, the next revision N might be assigned there, and would
+    # conflict with our revision N.
+    if "revision" not in spec:
+      # The regex finding busyRevisions above already ensures that revision
+      # numbers start with revisionPrefix, and has stripped the prefix.
+      spec["revision"] = revisionPrefix + str(
+        min(set(range(1, max(busyRevisions) + 2)) - busyRevisions)
+        if busyRevisions else 1)
 
     # Recreate symlinks to this development package builds.
     if spec["package"] in develPkgs:
@@ -878,6 +880,7 @@ def doBuild(args, parser):
       if spec["devel_hash"]+spec["deps_hash"] == spec["old_devel_hash"]:
         info("Development package %s does not need rebuild", spec["package"])
         buildOrder.pop(0)
+        packageIterations = 0
         continue
 
     # Now that we have all the information about the package we want to build, let's
@@ -1205,7 +1208,11 @@ def doBuild(args, parser):
 
     dieOnError(err, buildErrMsg)
 
-    syncHelper.syncToRemote(p, spec)
+    # Make sure not to upload local-only packages! These might have been
+    # produced in a previous run with a read-only remote store.
+    if not spec["revision"].startswith("local"):
+      syncHelper.syncToRemote(p, spec)
+
   banner("Build of %s successfully completed on `%s'.\n"
          "Your software installation is at:"
          "\n\n  %s\n\n"

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -10,7 +10,8 @@ BASH = "bash" if getstatusoutput("/bin/bash --version")[0] else "/bin/bash"
 
 def execute(command, printer=debug):
   popen = subprocess.Popen(command, shell=is_string(command), stdout=subprocess.PIPE)
-  for line in iter(popen.stdout.readline, ""):
+  lines_iterator = iter(popen.stdout.readline, "")
+  for line in lines_iterator:
     if not line: break
     printer("%s", to_unicode(line).strip("\n"))
   out = to_unicode(popen.communicate()[0]).strip("\n")

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -10,10 +10,9 @@ BASH = "bash" if getstatusoutput("/bin/bash --version")[0] else "/bin/bash"
 
 def execute(command, printer=debug):
   popen = subprocess.Popen(command, shell=is_string(command), stdout=subprocess.PIPE)
-  lines_iterator = iter(popen.stdout.readline, "")
-  for line in lines_iterator:
+  for line in iter(popen.stdout.readline, ""):
     if not line: break
-    printer(to_unicode(line).strip("\n")) # yield line
+    printer("%s", to_unicode(line).strip("\n"))
   out = to_unicode(popen.communicate()[0]).strip("\n")
   if out:
     printer(out)

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -107,7 +107,7 @@ def dummy_open(x, mode="r"):
       "/sw/BUILD/27ce49698e818e8efb56b6eff6dd785e503df341/defaults-release/.build_succeeded": (0, StringIO("0")),
       "/sw/BUILD/3e90b4e08bad439fa5f25282480d1adb9efb0c0d/zlib/.build_succeeded": (0, StringIO("0")),
       "/sw/BUILD/%s/ROOT/.build_succeeded" % TEST_ROOT_BUILD_HASH: (0, StringIO("0")),
-      "/sw/osx_x86-64/defaults-release/v1-local1/.build-hash": (1, StringIO("27ce49698e818e8efb56b6eff6dd785e503df341")),
+      "/sw/osx_x86-64/defaults-release/v1-1/.build-hash": (1, StringIO("27ce49698e818e8efb56b6eff6dd785e503df341")),
       "/sw/osx_x86-64/zlib/v1.2.3-local1/.build-hash": (1, StringIO("3e90b4e08bad439fa5f25282480d1adb9efb0c0d")),
       "/sw/osx_x86-64/ROOT/v6-08-30-local1/.build-hash": (1, StringIO(TEST_ROOT_BUILD_HASH))
     }
@@ -132,7 +132,7 @@ def dummy_execute(x, mock_git_clone, mock_git_fetch, **kwds):
     mock_git_fetch()
     return 0
   return {
-    "/bin/bash -e -x /sw/SPECS/osx_x86-64/defaults-release/v1-local1/build.sh 2>&1": 0,
+    "/bin/bash -e -x /sw/SPECS/osx_x86-64/defaults-release/v1-1/build.sh 2>&1": 0,
     '/bin/bash -e -x /sw/SPECS/osx_x86-64/zlib/v1.2.3-local1/build.sh 2>&1': 0,
     '/bin/bash -e -x /sw/SPECS/osx_x86-64/ROOT/v6-08-30-local1/build.sh 2>&1': 0,
     "git clone --filter=blob:none --bare https://github.com/star-externals/zlib /sw/MIRROR/zlib": 0,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -107,9 +107,9 @@ def dummy_open(x, mode="r"):
       "/sw/BUILD/27ce49698e818e8efb56b6eff6dd785e503df341/defaults-release/.build_succeeded": (0, StringIO("0")),
       "/sw/BUILD/3e90b4e08bad439fa5f25282480d1adb9efb0c0d/zlib/.build_succeeded": (0, StringIO("0")),
       "/sw/BUILD/%s/ROOT/.build_succeeded" % TEST_ROOT_BUILD_HASH: (0, StringIO("0")),
-      "/sw/osx_x86-64/defaults-release/v1-1/.build-hash": (1, StringIO("27ce49698e818e8efb56b6eff6dd785e503df341")),
-      "/sw/osx_x86-64/zlib/v1.2.3-1/.build-hash": (1, StringIO("3e90b4e08bad439fa5f25282480d1adb9efb0c0d")),
-      "/sw/osx_x86-64/ROOT/v6-08-30-1/.build-hash": (1, StringIO(TEST_ROOT_BUILD_HASH))
+      "/sw/osx_x86-64/defaults-release/v1-local1/.build-hash": (1, StringIO("27ce49698e818e8efb56b6eff6dd785e503df341")),
+      "/sw/osx_x86-64/zlib/v1.2.3-local1/.build-hash": (1, StringIO("3e90b4e08bad439fa5f25282480d1adb9efb0c0d")),
+      "/sw/osx_x86-64/ROOT/v6-08-30-local1/.build-hash": (1, StringIO(TEST_ROOT_BUILD_HASH))
     }
     if not x in known:
       return DEFAULT
@@ -132,9 +132,9 @@ def dummy_execute(x, mock_git_clone, mock_git_fetch, **kwds):
     mock_git_fetch()
     return 0
   return {
-    "/bin/bash -e -x /sw/SPECS/osx_x86-64/defaults-release/v1-1/build.sh 2>&1": 0,
-    '/bin/bash -e -x /sw/SPECS/osx_x86-64/zlib/v1.2.3-1/build.sh 2>&1': 0,
-    '/bin/bash -e -x /sw/SPECS/osx_x86-64/ROOT/v6-08-30-1/build.sh 2>&1': 0,
+    "/bin/bash -e -x /sw/SPECS/osx_x86-64/defaults-release/v1-local1/build.sh 2>&1": 0,
+    '/bin/bash -e -x /sw/SPECS/osx_x86-64/zlib/v1.2.3-local1/build.sh 2>&1': 0,
+    '/bin/bash -e -x /sw/SPECS/osx_x86-64/ROOT/v6-08-30-local1/build.sh 2>&1': 0,
     "git clone --filter=blob:none --bare https://github.com/star-externals/zlib /sw/MIRROR/zlib": 0,
     "git clone --filter=blob:none --bare https://github.com/root-mirror/root /sw/MIRROR/root": 0,
     "cat /sw/MIRROR/fetch-log.txt": 0,

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -16,7 +16,7 @@ class CmdTestCase(unittest.TestCase):
     def test_execute(self, mock_debug):
       err = execute("echo foo", mock_debug)
       self.assertEqual(err, 0)
-      self.assertEqual(mock_debug.mock_calls, [call('foo')])
+      self.assertEqual(mock_debug.mock_calls, [call("%s", "foo")])
       mock_debug.reset_mock()
       err = execute("echoo 2> /dev/null", mock_debug)
       self.assertEqual(err, 127)


### PR DESCRIPTION
This prevents interference between the remote store and local builds in the case where another machine builds a package and uploads it to the remote store with a revision number that conflicts with a local package, in case that package wasn't uploaded to the remote store. In that case, local revision numbers become a mess, and packages could start depending on the wrong revision numbers of dependencies.

It also prevents builds intended only for local use from being uploaded to the remote. This is important as local-only builds might otherwise be uploaded to the remote much later, when some of their dependencies might conflict with new ones on the remote, and would be renamed. In that case, we currently don't update the main package, so it would depend on (and e.g. try to source scripts from) an incorrect revision number of its dependency.

With these changes, if running aliBuild with a read-write remote when some local revisions are left over in the local store from a previous run, then those revisions are not uploaded, and may be deleted from the local store. Running aliBuild repeatedly with a read-only remote preserves local revisions.