### PR TITLE
Calculate separate hashes for local and remote revisions

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -267,13 +267,13 @@ class BuildTestCase(unittest.TestCase):
     syncers = [NoRemoteSync(),
                HttpRemoteSync(remoteStore="https://local/test", architecture="osx_x86-64", workdir="/sw", insecure=False),
                RsyncRemoteSync(remoteStore="ssh://local/test", writeStore="ssh://local/test", architecture="osx_x86-64", workdir="/sw", rsyncOptions="")]
-    dummy_spec = { "package"        : "zlib",
-                   "version"        : "v1.2.3",
-                   "revision"       : "1",
-                   "storePath"      : "/sw/path",
-                   "linksPath"      : "/sw/links",
-                   "tarballHashDir" : "/sw/TARS",
-                   "tarballLinkDir" : "/sw/TARS" }
+    dummy_spec = {"package": "zlib",
+                  "version": "v1.2.3",
+                  "revision": "1",
+                  "remote_store_path": "/sw/path",
+                  "remote_links_path": "/sw/links",
+                  "remote_tar_hash_dir": "/sw/TARS",
+                  "remote_tar_link_dir": "/sw/TARS"}
 
     class mockRequest:
       def __init__(self, j, simulate_err=False):
@@ -299,10 +299,10 @@ class BuildTestCase(unittest.TestCase):
     def mockGet(url, *a, **b):
       if "triggers_a_404" in url:
         return mockRequest(None)
-      if dummy_spec["storePath"] in url:
-        if dummy_spec["hash"].startswith("deadbeef"):
+      if dummy_spec["remote_store_path"] in url:
+        if dummy_spec["remote_revision_hash"].startswith("deadbeef"):
           return mockRequest([{ "name": "zlib-v1.2.3-1.slc7_x86-64.tar.gz" }])
-        elif dummy_spec["hash"].startswith("baadf00d"):
+        elif dummy_spec["remote_revision_hash"].startswith("baadf00d"):
           return mockRequest([{ "name": "zlib-v1.2.3-2.slc7_x86-64.tar.gz" }], simulate_err=True)
       else:
         return mockRequest([{ "name":"zlib-v1.2.3-1.slc7_x86-64.tar.gz" },
@@ -312,12 +312,12 @@ class BuildTestCase(unittest.TestCase):
     mock_os.path.isfile.side_effect = lambda x: False  # file does not exist locally: force download
 
     for testHash in [ "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "baadf00dbaadf00dbaadf00dbaadf00dbaadf00d" ]:
-      dummy_spec["hash"] = testHash
+      dummy_spec["remote_revision_hash"] = testHash
       for x in syncers:
         x.syncToLocal("zlib", dummy_spec)
         x.syncToRemote("zlib", dummy_spec)
 
-    dummy_spec["storePath"] = "/triggers_a_404/path"
+    dummy_spec["remote_store_path"] = "/triggers_a_404/path"
     for x in syncers:
       x.syncToLocal("zlib", dummy_spec)
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -70,8 +70,8 @@ append_path:
 make
 make install
 """
-TEST_ROOT_BUILD_HASH = "2cb80ea18ac9ec56b94c4d9a865caa1f7e03a8f0" if sys.version_info[0] < 3 else \
-                       "1fc9be611d016280a2a66519923965839d0d009b"
+TEST_ROOT_BUILD_HASH = "96cf657d1a5e2d41f16dfe42ced8c3522ab4e413" if sys.version_info[0] < 3 else \
+                       "8ec3f41b6b585ef86a02e9c595eed67f34d63f08"
 
 TEST_DEFAULT_RELEASE = """package: defaults-release
 version: v1
@@ -105,10 +105,10 @@ def dummy_open(x, mode="r"):
   if mode == "r":
     known = {
       "/sw/BUILD/27ce49698e818e8efb56b6eff6dd785e503df341/defaults-release/.build_succeeded": (0, StringIO("0")),
-      "/sw/BUILD/3e90b4e08bad439fa5f25282480d1adb9efb0c0d/zlib/.build_succeeded": (0, StringIO("0")),
+      "/sw/BUILD/8cd1f56c450f05ffbba3276bad08eae30f814999/zlib/.build_succeeded": (0, StringIO("0")),
       "/sw/BUILD/%s/ROOT/.build_succeeded" % TEST_ROOT_BUILD_HASH: (0, StringIO("0")),
       "/sw/osx_x86-64/defaults-release/v1-1/.build-hash": (1, StringIO("27ce49698e818e8efb56b6eff6dd785e503df341")),
-      "/sw/osx_x86-64/zlib/v1.2.3-local1/.build-hash": (1, StringIO("3e90b4e08bad439fa5f25282480d1adb9efb0c0d")),
+      "/sw/osx_x86-64/zlib/v1.2.3-local1/.build-hash": (1, StringIO("8cd1f56c450f05ffbba3276bad08eae30f814999")),
       "/sw/osx_x86-64/ROOT/v6-08-30-local1/.build-hash": (1, StringIO(TEST_ROOT_BUILD_HASH))
     }
     if not x in known:
@@ -191,7 +191,7 @@ class BuildTestCase(unittest.TestCase):
         "/sw/TARS/osx_x86-64/zlib/zlib-v1.2.3-*.osx_x86-64.tar.gz": [],
         "/sw/TARS/osx_x86-64/ROOT/ROOT-v6-08-30-*.osx_x86-64.tar.gz": [],
         "/sw/TARS/osx_x86-64/store/27/27ce49698e818e8efb56b6eff6dd785e503df341/*gz": [],
-        "/sw/TARS/osx_x86-64/store/3e/3e90b4e08bad439fa5f25282480d1adb9efb0c0d/*gz": [],
+        "/sw/TARS/osx_x86-64/store/8c/8cd1f56c450f05ffbba3276bad08eae30f814999/*gz": [],
         "/sw/TARS/osx_x86-64/store/%s/%s/*gz" % (TEST_ROOT_BUILD_HASH[0:2], TEST_ROOT_BUILD_HASH): [],
         "/sw/TARS/osx_x86-64/defaults-release/defaults-release-v1-1.osx_x86-64.tar.gz": ["../../osx_x86-64/store/27/27ce49698e818e8efb56b6eff6dd785e503df341/defaults-release-v1-1.osx_x86-64.tar.gz"],
       }[x]


### PR DESCRIPTION
Local revisions get a different hash (with the same information as remote revisions, but an extra "local" string in the input to the hash). This is to avoid conflicts where a remote might gain a package with the same hash as a locally-built package; in that case, the two would conflict. With this patch, the two revisions of the same package should be able to coexist.

Syncing from and to remote stores can always use the remote-specific hashes. Once we have assigned a revision to the package (or reused an existing one), we know which hash (remote or local) to assign and use for the build.

This commit also extracts the hash calculation into a separate function for cleanliness.

The same hashes are still generated for the same specs, so existing tarballs on the remote store are used.

A bit of reorganisation was necessary to move the hash calculation into the main build loop, as we need to know our dependencies' hashes at the time we calculate our own hash, but to know their hashes, they must have first been assigned a revision number (so that we know whether to use the local or remote hash).

I've tested this by building O2 and AliPhysics on slc7; aliBuild successfully reuses existing packages from the store, and builds some locally with localN revisions. I haven't run into a situation where a remote store package was built with the same config as an already-existing local package, but the separate local/remote hashes should solve that. I think the best way to test that is probably to deploy this change on a CI builder for a little while and see how it goes.

Supersedes #666; this PR is split into three commits (see also their descriptions). Each commit passes the unit tests individually; together, they are equivalent to #666 modulo some very minor refactoring of `storeHashes`.