### PR TITLE
Update existing git repos if we can't checkout the tag

### DIFF
--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -92,7 +92,11 @@ if [[ ! "$SOURCE0" == '' && "${SOURCE0:0:1}" != "/" ]]; then
   else
     # Folder is already present, but check that it is the right tag
     cd $SOURCEDIR
-    git checkout "${GIT_TAG}"
+    if ! git checkout "$GIT_TAG"; then
+      # If we can't find the tag, it might be new. Fetch tags and try again.
+      git fetch -f "$SOURCE0" "refs/tags/$GIT_TAG:refs/tags/$GIT_TAG"
+      git checkout "$GIT_TAG"
+    fi
   fi
 elif [[ ! "$SOURCE0" == '' && "${SOURCE0:0:1}" == "/" ]]; then
   ln -snf $SOURCE0 $SOURCEDIR


### PR DESCRIPTION
This fetches the tags of existing git repos if desired tag can't be checked out, then retries checking out the desired tag. This only results in an extra network request per repo (which might mean an extra password prompt) if the tag doesn't already exist, which happens if the tag was made after the repo in `SOURCES` was first cloned.

This doesn't catch cases where a tag moves, or where `$GIT_TAG` is a branch, not a
tag.