### PR TITLE
Don't redownload existing symlinks

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -215,6 +215,12 @@ class HttpRemoteSync:
                      n = pkg["name"],
                      ld = spec["remote_tar_link_dir"])
         execute(cmd)
+      elif os.path.islink(join(spec["remote_tar_link_dir"], pkg["name"])):
+        # Do not redownload twice. The download isn't large, but if we have
+        # lots of small files it takes a while. With local revisions, we won't
+        # produce revisions that will conflict with remote revisions unless we
+        # upload them anyway, so there's no need to redownload.
+        pass
       else:
         linkTarget = self.getRetry(
           "/".join((self.remoteStore, spec["remote_links_path"], pkg["name"])),


### PR DESCRIPTION
We shouldn't be producing conflicting symlinks anyway, and if we do, it's probably better if we just keep our local one.

This should reduce the remote sync time significantly on subsequent runs of aliBuild (though we'll still have to download everything on the first run).

On slc7, when we don't have to rebuild anything, this change takes the runtime of `aliBuild build O2 --defaults o2` from 5 minutes to 16 seconds.