### PR TITLE
Revert "Use standard name for upstream remotes."

### DIFF
--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -39,7 +39,7 @@ def doInit(args):
   if path.exists(args.configDir):
     warning("using existing recipes from %s", args.configDir)
   else:
-    cmd = format("git clone --origin upstream %(pcf)s %(repo)s%(branch)s %(cd)s",
+    cmd = format("git clone %(pcf)s %(repo)s%(branch)s %(cd)s",
                  pcf=partialCloneFilter,
                  repo=args.dist["repo"] if ":" in args.dist["repo"] else "https://github.com/%s" % args.dist["repo"],
                  branch=" -b "+args.dist["ver"] if args.dist["ver"] else "",
@@ -86,8 +86,8 @@ def doInit(args):
     debug("cloning %s%s for development", spec["package"], " version "+p["ver"] if p["ver"] else "")
 
     updateReferenceRepoSpec(args.referenceSources, spec["package"], spec, True)
-    cmd = format("git clone --origin upstream %(pcf)s %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
-                 "cd %(cd)s && git remote set-url --push upstream %(writeRepo)s",
+    cmd = format("git clone %(pcf)s %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
+                 "cd %(cd)s && git remote set-url --push origin %(writeRepo)s",
                  pcf=partialCloneFilter,
                  readRepo=spec["source"],
                  writeRepo=writeRepo,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,8 +41,8 @@ def dummy_exists(x):
   return False
 
 CLONE_EVERYTHING = [
- call(u'git clone --origin upstream --filter=blob:none https://github.com/alisw/alidist -b master /alidist'),
- call(u'git clone --origin upstream --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push upstream https://github.com/alisw/AliRoot')
+ call(u'git clone --filter=blob:none https://github.com/alisw/alidist -b master /alidist'),
+ call(u'git clone --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot')
 ]
 
 class InitTestCase(unittest.TestCase):
@@ -106,7 +106,7 @@ class InitTestCase(unittest.TestCase):
         architecture = "slc7_x86-64"
       )
       doInit(args)
-      mock_execute.assert_called_with("git clone --origin upstream --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push upstream https://github.com/alisw/AliRoot")
+      mock_execute.assert_called_with("git clone --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot")
       self.assertEqual(mock_execute.mock_calls, CLONE_EVERYTHING)
       mock_path.exists.assert_has_calls([call('.'), call('/sw/MIRROR'), call('/alidist'), call('./AliRoot')])
 
@@ -115,7 +115,7 @@ class InitTestCase(unittest.TestCase):
       mock_path.reset_mock()
       args.fetchRepos = True
       doInit(args)
-      mock_execute.assert_called_with("git clone --origin upstream --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push upstream https://github.com/alisw/AliRoot")
+      mock_execute.assert_called_with("git clone --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push origin https://github.com/alisw/AliRoot")
       self.assertEqual(mock_execute.mock_calls, CLONE_EVERYTHING)
       mock_path.exists.assert_has_calls([call('.'), call('/sw/MIRROR'), call('/alidist'), call('./AliRoot')])
 


### PR DESCRIPTION
Reverts alisw/alibuild#670