### PR TITLE
Fix directory listing using S3 HTTPS API

### DIFF
--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -91,7 +91,7 @@ class HttpRemoteSync:
           s3Request = re.match("https://s3.cern.ch/swift/v1[/]+([^/]*)/(.*)$", url)
           if s3Request:
             [bucket, prefix] = s3Request.groups()
-            url = "https://s3.cern.ch/swift/v1/%s/?prefix=%s" % (bucket, prefix.strip("/"))
+            url = "https://s3.cern.ch/swift/v1/%s/?prefix=%s" % (bucket, prefix.lstrip("/"))
             resp = get(url, verify=not self.insecure, timeout=self.httpTimeoutSec)
             if resp.status_code == 404:
               # No need to retry any further


### PR DESCRIPTION
Previously, trailing slashes would be stripped from paths. This led to unintended symlinks being created under `TARS`, e.g. when trying to fetch `TARS/slc7_x86-64/O2/`, `TARS/slc7_x86-64/O2` would be used as the prefix instead, leading to O2Suite symlinks being included in the result as well.

We do want to strip leading slashes from the prefix, so use `str.lstrip` instead.