### PR TITLE
Make doBuild's return type more sane

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -81,9 +81,8 @@ def doMain(args, parser):
     exit(0)
 
   if args.action == "build":
-    printer, msg, code = doBuild(args, parser)
-    printer(msg)
-    exit(code)
+    sys.exit(doBuild(args, parser))
+
 
 if __name__ == "__main__":
   args, parser = doParseArgs(star())

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -229,9 +229,11 @@ def doBuild(args, parser):
   prunePaths(workDir)
 
   if not exists(args.configDir):
-    return (error, ("Cannot find %sdist recipes under directory \"%s\".\n" +
-                    "Maybe you need to \"cd\" to the right directory or " +
-                    "you forgot to run \"aliBuild init\"?") % (star(), args.configDir), 1)
+    error('Cannot find %sdist recipes under directory "%s".\n'
+          'Maybe you need to "cd" to the right directory or '
+          'you forgot to run "%sBuild init"?',
+          star(), args.configDir, star())
+    return 1
 
   err, value = getstatusoutput("GIT_DIR=%s/.git git symbolic-ref -q HEAD" % args.configDir)
   branch_basename = re.sub("refs/heads/", "", value)
@@ -283,17 +285,15 @@ def doBuild(args, parser):
                                                                         taps                    = taps,
                                                                         log                     = debug)
   if validDefaults and args.defaults not in validDefaults:
-    return (error, "Specified default `%s' is not compatible with the packages you want to build.\n" % args.defaults +
-                   "Valid defaults:\n\n- " +
-                   "\n- ".join(sorted(validDefaults)), 1)
+    error("Specified default `%s' is not compatible with the packages you want to build.\n"
+          "Valid defaults:\n\n- %s", args.defaults, "\n- ".join(sorted(validDefaults)))
+    return 1
 
   if failed:
-    return (error,
-            "The following packages are system requirements and could not be found:\n\n- {failed}\n\n"
-            "Please run:\n\n\t{star}Doctor --defaults {defaults} {pkgname}\n\nto get a full diagnosis."
-            .format(star=star(), pkgname=args.pkgname.pop(), defaults=args.defaults,
-                    failed="\n- ".join(sorted(list(failed)))),
-            1)
+    error("The following packages are system requirements and could not be found:\n\n- %s\n\n"
+          "Please run:\n\n\t%sDoctor --defaults %s %s\n\nto get a full diagnosis.",
+          "\n- ".join(sorted(list(failed))), star(), args.defaults, args.pkgname.pop())
+    return 1
 
   for x in specs.values():
     x["requires"] = [r for r in x["requires"] if not r in args.disable]
@@ -340,10 +340,11 @@ def doBuild(args, parser):
                if p in develCandidates and p not in args.noDevel]
   develPkgsUpper = [(p, p.upper()) for p in buildOrder
                     if p.upper() in develCandidatesUpper and p not in args.noDevel]
-  if set(develPkgs) != set(x for (x, y) in develPkgsUpper):
-    return (error, format("The following development packages have wrong spelling: %(pkgs)s.\n"
-                          "Please check your local checkout and adapt to the correct one indicated.",
-                          pkgs=", ".join(set(x.strip() for (x,y) in develPkgsUpper) - set(develPkgs))), 1)
+  if set(develPkgs) != {x for x, _ in develPkgsUpper}:
+    error("The following development packages have the wrong spelling: %s.\n"
+          "Please check your local checkout and adapt to the correct one indicated.",
+          ", ".join({x.strip() for x, _ in develPkgsUpper} - set(develPkgs)))
+    return 1
 
   if buildOrder:
     banner("Packages will be built in the following order:\n - %s",
@@ -425,7 +426,9 @@ def doBuild(args, parser):
           err, out = getstatusoutput("cd %s && git rev-parse HEAD" % spec["source"])
           out = out[0:10]
         if err:
-          return (error, "Error, unable to lookup changes in development package %s. Is it a git clone?" % spec["source"], 1)
+          error("Error, unable to lookup changes in development package %s. Is it a git clone?",
+                spec["source"])
+          return 1
         develPackageBranch = out.replace("/", "-")
         spec["tag"] = args.develPrefix if "develPrefix" in args else develPackageBranch
         spec["commit_hash"] = "0"
@@ -446,7 +449,8 @@ def doBuild(args, parser):
   # If one of the special packages is in the list of packages to be built,
   # we use it as main package, rather than the last one.
   if not buildOrder:
-    return (banner, "Nothing to be done.", 0)
+    banner("Nothing to be done.")
+    return 0
   mainPackage = buildOrder[-1]
   mainHash = specs[mainPackage]["commit_hash"]
 
@@ -490,7 +494,8 @@ def doBuild(args, parser):
 
   debug("We will build packages in the following order: %s", " ".join(buildOrder))
   if args.dryRun:
-    return (info, "--dry-run / -n specified. Not building.", 0)
+    info("--dry-run / -n specified. Not building.")
+    return 0
 
   # We now iterate on all the packages, making sure we build correctly every
   # single one of them. This is done this way so that the second time we run we
@@ -510,7 +515,9 @@ def doBuild(args, parser):
   while buildOrder:
     packageIterations += 1
     if packageIterations > 20:
-      return (error, "Too many attempts at building %s. Something wrong with the repository?" % spec["package"], 1)
+      error("Too many attempts at building %s. Something wrong with the repository?",
+            spec["package"])
+      return 1
     p = buildOrder[0]
     spec = specs[p]
     if args.debug:
@@ -1068,5 +1075,5 @@ def doBuild(args, parser):
   for x in develPkgs:
     banner("Build directory for devel package %s:\n%s/BUILD/%s-latest%s/%s",
            x, abspath(args.workDir), x, "-"+args.develPrefix if "develPrefix" in args else "", x)
-  return (debug, "Everything done", 0)
-
+  debug("Everything done")
+  return 0


### PR DESCRIPTION
Previously, `doBuild` returned a logging function, a message and an exit code. We only really need the exit code, and might as well do the logging in `doBuild` itself.

The unit tests can still check for the correct final logging message with a mock logging function.