### PR TITLE
Allow running tests on unknown architectures

### DIFF
--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -180,29 +180,27 @@ def doParseArgs(star):
   args = finaliseArgs(parser.parse_args(), parser, star)
   return (args, parser)
 
-VALID_ARCHS_RE = ["slc[5-9]+_(x86-64|ppc64)",
-                  "(ubuntu|ubt|osx|fedora)[0-9]*_x86-64",
-                 ]
+VALID_ARCHS_RE = "^slc[5-9]_(x86-64|ppc64)$|^(ubuntu|ubt|osx|fedora)[0-9]*_x86-64$"
 
 def matchValidArch(architecture):
-  return [x for x in VALID_ARCHS_RE if re.match(x, architecture)]
+  return bool(re.match(VALID_ARCHS_RE, architecture))
 
-ARCHITECTURE_TABLE = [
-           "On Linux, x86-64:\n"
-           "   RHEL5 / SLC5 compatible: slc5_x86-64\n"
-           "   RHEL6 / SLC6 compatible: slc6_x86-64\n"
-           "   RHEL7 / CC7 compatible: slc7_x86-64\n"
-           "   Ubuntu 14.04 compatible: ubuntu1404_x86-64\n"
-           "   Ubuntu 15.04 compatible: ubuntu1504_x86-64\n"
-           "   Ubuntu 15.10 compatible: ubuntu1510_x86-64\n"
-           "   Ubuntu 16.04 compatible: ubuntu1604_x86-64\n"
-           "   Fedora 25 compatible: fedora25_x86-64\n"
-           "   Fedora 26 compatible: fedora26_x86-64\n\n"
-           "On Linux, POWER8 / PPC64 (little endian):\n"
-           "   RHEL7 / CC7 compatible: slc7_ppc64\n\n"
-           "On Mac, x86-64:\n"
-           "   Yosemite and El-Captain: osx_x86-64\n\n"
-      ]
+ARCHITECTURE_TABLE = """\
+On Linux, x86-64:
+   RHEL6 / SLC6 compatible: slc6_x86-64
+   RHEL7 / CC7 compatible: slc7_x86-64
+   RHEL8 / CC8 compatible: slc8_x86-64
+   Ubuntu 18.04 compatible: ubuntu1804_x86-64
+   Ubuntu 20.04 compatible: ubuntu2004_x86-64
+   Fedora 33 compatible: fedora33_x86-64
+   Fedora 34 compatible: fedora34_x86-64
+
+On Linux, POWER8 / PPC64 (little endian):
+   RHEL7 / CC7 compatible: slc7_ppc64
+
+On Mac, x86-64:
+   Yosemite to Big Sur: osx_x86-64
+"""
 
 def finaliseArgs(args, parser, star):
 
@@ -213,14 +211,12 @@ def finaliseArgs(args, parser, star):
   # --architecture can be specified in both clean and build.
   if args.action in  ["build", "clean"]:
     if not args.architecture:
-      parser.error(format("Cannot determine architecture. "
-                   "Please pass it explicitly.\n\n%s" % ARCHITECTURE_TABLE[0]))
+      parser.error("Cannot determine architecture. Please pass it explicitly.\n\n"
+                   + ARCHITECTURE_TABLE)
     if not args.forceUnknownArch and not matchValidArch(args.architecture):
-      parser.error(format("Unknown / unsupported architecture: %(architecture)s.\n\n"
-                  "%(table)s"
-                  "Alternatively, you can use the `--force-unknown-architecture' option.",
-                  table=ARCHITECTURE_TABLE[0],
-                  architecture=args.architecture))
+      parser.error("Unknown / unsupported architecture: {architecture}.\n\n{table}"
+                   "Alternatively, you can use the `--force-unknown-architecture' option."
+                   .format(table=ARCHITECTURE_TABLE, architecture=args.architecture))
 
     args.disable = normalise_multiple_options(args.disable)
 

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -8,7 +8,7 @@ except ImportError:
     from mock import patch, call  # Python 2
 
 import alibuild_helpers.args
-from alibuild_helpers.args import doParseArgs, matchValidArch, finaliseArgs, DEFAULT_WORK_DIR, DEFAULT_CHDIR
+from alibuild_helpers.args import doParseArgs, matchValidArch, finaliseArgs, DEFAULT_WORK_DIR, DEFAULT_CHDIR, ARCHITECTURE_TABLE
 import argparse
 import sys
 import os
@@ -26,65 +26,58 @@ else:
   ANALYTICS_MISSING_STATE_ERROR = "too few arguments"
 
 # A few errors we should handle, together with the expected result
-ARCHITECTURE_ERROR = [call(u"Unknown / unsupported architecture: foo.\n\nOn Linux, x86-64:\n   RHEL5 / SLC5 compatible: slc5_x86-64\n   RHEL6 / SLC6 compatible: slc6_x86-64\n   RHEL7 / CC7 compatible: slc7_x86-64\n   Ubuntu 14.04 compatible: ubuntu1404_x86-64\n   Ubuntu 15.04 compatible: ubuntu1504_x86-64\n   Ubuntu 15.10 compatible: ubuntu1510_x86-64\n   Ubuntu 16.04 compatible: ubuntu1604_x86-64\n   Fedora 25 compatible: fedora25_x86-64\n   Fedora 26 compatible: fedora26_x86-64\n\nOn Linux, POWER8 / PPC64 (little endian):\n   RHEL7 / CC7 compatible: slc7_ppc64\n\nOn Mac, x86-64:\n   Yosemite and El-Captain: osx_x86-64\n\nAlternatively, you can use the `--force-unknown-architecture' option.")]
+ARCHITECTURE_ERROR = [call(u"Unknown / unsupported architecture: foo.\n\n{table}Alternatively, you can use the `--force-unknown-architecture' option.".format(table=ARCHITECTURE_TABLE))]
 PARSER_ERRORS = {
-  "build": [call(BUILD_MISSING_PKG_ERROR)],
-  "build zlib --foo": [call('unrecognized arguments: --foo')],
+  "build --force-unknown-architecture": [call(BUILD_MISSING_PKG_ERROR)],
+  "build --force-unknown-architecture zlib --foo": [call('unrecognized arguments: --foo')],
   "init --docker-image": [call('unrecognized arguments: --docker-image')],
-  "builda zlib" : [call("argument action: invalid choice: 'builda' (choose from 'analytics', 'architecture', 'build', 'clean', 'deps', 'doctor', 'init', 'version')")],
-  "build zlib --no-system --always-prefer-system" : [call('argument --always-prefer-system: not allowed with argument --no-system')],
+  "builda --force-unknown-architecture zlib" : [call("argument action: invalid choice: 'builda' (choose from 'analytics', 'architecture', 'build', 'clean', 'deps', 'doctor', 'init', 'version')")],
+  "build --force-unknown-architecture zlib --no-system --always-prefer-system" : [call('argument --always-prefer-system: not allowed with argument --no-system')],
   "build zlib --architecture foo": ARCHITECTURE_ERROR,
   "clean --architecture foo": ARCHITECTURE_ERROR,
-  "build zlib --remote-store rsync://test1.local/::rw --write-store rsync://test2.local/::rw ": [call('cannot specify ::rw and --write-store at the same time')],
+  "build --force-unknown-architecture zlib --remote-store rsync://test1.local/::rw --write-store rsync://test2.local/::rw ": [call('cannot specify ::rw and --write-store at the same time')],
   "build zlib -a osx_x86-64 --docker-image foo": [call('cannot use `-a osx_x86-64` and --docker')],
   "analytics": [call(ANALYTICS_MISSING_STATE_ERROR)]
 }
 
 # A few valid archs
-VALID_ARCHS = [
-  "osx_x86-64",
-  "slc7_x86-64"
-]
-
-INVALID_ARCHS = [
-  "osx_x86-64",
-  "sl8_x86-64"
-]
+VALID_ARCHS = ["osx_x86-64", "slc7_x86-64", "slc8_x86-64"]
+INVALID_ARCHS = ["osx_ppc64", "sl8_x86-64"]
 
 class FakeExit(Exception):
   pass
 
 CORRECT_BEHAVIOR = [
-  ((), "build zlib"                                                       , [("action", "build"), ("workDir", "sw"), ("referenceSources", "sw/MIRROR")]),
-  ((), "init"                                                             , [("action", "init"), ("workDir", "sw"), ("referenceSources", "sw/MIRROR")]),
-  ((), "version"                                                          , [("action", "version")]),
-  ((), "clean"                                                            , [("action", "clean"), ("workDir", "sw"), ("referenceSources", "sw/MIRROR")]),
-  ((), "build -j 10 zlib"                                                 , [("action", "build"), ("jobs", 10), ("pkgname", ["zlib"])]),
-  ((), "build -j 10 zlib --disable gcc --disable foo"                     , [("disable", ["gcc", "foo"])]),
-  ((), "build -j 10 zlib --disable gcc --disable foo,bar"                 , [("disable", ["gcc", "foo", "bar"])]),
-  ((), "init zlib --dist master"                                          , [("dist", {"repo": "alisw/alidist", "ver": "master"})]),
-  ((), "init zlib --dist ktf/alidist@dev"                                 , [("dist", {"repo": "ktf/alidist", "ver": "dev"})]),
-  ((), "build zlib --remote-store rsync://test.local/"                    , [("noSystem", True)]),
-  ((), "build zlib --remote-store rsync://test.local/::rw"                , [("noSystem", True), ("remoteStore", "rsync://test.local/"), ("writeStore", "rsync://test.local/")]),
-  ((), "build zlib --architecture slc7_x86-64"                            , [("noSystem", True), ("preferSystem", False), ("remoteStore", "https://s3.cern.ch/swift/v1/alibuild-repo")]),
-  ((), "build zlib --architecture ubuntu1804_x86-64"                      , [("noSystem", False), ("preferSystem", False), ("remoteStore", "")]),
-  ((), "build zlib -a slc7_x86-64 --docker-image alisw/slc7-builder"      , [("docker", True), ("dockerImage", "alisw/slc7-builder")]),
-  ((), "build zlib -a slc7_x86-64 --docker"                               , [("docker", True), ("dockerImage", "alisw/slc7-builder")]),
-  ((), "build zlib --devel-prefix -a slc7_x86-64 --docker"                , [("docker", True), ("dockerImage", "alisw/slc7-builder"), ("develPrefix", "%s-slc7_x86-64" % os.path.basename(os.getcwd()))]),
-  ((), "build zlib --devel-prefix -a slc7_x86-64 --docker-image someimage", [("docker", True), ("dockerImage", "someimage"), ("develPrefix", "%s-slc7_x86-64" % os.path.basename(os.getcwd()))]),
-  ((), "--debug build --defaults o2 O2"                                   , [("debug", True), ("action",  "build"), ("defaults", "o2"), ("pkgname", ["O2"])]),
-  ((), "build --debug --defaults o2 O2"                                   , [("debug", True), ("action",  "build"), ("defaults", "o2"), ("pkgname", ["O2"])]),
-  ((), "init -z test zlib"                                                , [("configDir", "test/alidist")]),
-  ((), "build -z test zlib"                                               , [("configDir", "alidist")]),
-  ((), "analytics off"                                                    , [("state", "off")]),
-  ((), "analytics on"                                                     , [("state", "on")]),
+  ((), "build --force-unknown-architecture zlib"                                       , [("action", "build"), ("workDir", "sw"), ("referenceSources", "sw/MIRROR")]),
+  ((), "init"                                                                          , [("action", "init"), ("workDir", "sw"), ("referenceSources", "sw/MIRROR")]),
+  ((), "version"                                                                       , [("action", "version")]),
+  ((), "clean --force-unknown-architecture"                                            , [("action", "clean"), ("workDir", "sw"), ("referenceSources", "sw/MIRROR")]),
+  ((), "build --force-unknown-architecture -j 10 zlib"                                 , [("action", "build"), ("jobs", 10), ("pkgname", ["zlib"])]),
+  ((), "build --force-unknown-architecture -j 10 zlib --disable gcc --disable foo"     , [("disable", ["gcc", "foo"])]),
+  ((), "build --force-unknown-architecture -j 10 zlib --disable gcc --disable foo,bar" , [("disable", ["gcc", "foo", "bar"])]),
+  ((), "init zlib --dist master"                                                       , [("dist", {"repo": "alisw/alidist", "ver": "master"})]),
+  ((), "init zlib --dist ktf/alidist@dev"                                              , [("dist", {"repo": "ktf/alidist", "ver": "dev"})]),
+  ((), "build --force-unknown-architecture zlib --remote-store rsync://test.local/"    , [("noSystem", True)]),
+  ((), "build --force-unknown-architecture zlib --remote-store rsync://test.local/::rw", [("noSystem", True), ("remoteStore", "rsync://test.local/"), ("writeStore", "rsync://test.local/")]),
+  ((), "build zlib --architecture slc7_x86-64"                                         , [("noSystem", True), ("preferSystem", False), ("remoteStore", "https://s3.cern.ch/swift/v1/alibuild-repo")]),
+  ((), "build zlib --architecture ubuntu1804_x86-64"                                   , [("noSystem", False), ("preferSystem", False), ("remoteStore", "")]),
+  ((), "build zlib -a slc7_x86-64 --docker-image alisw/slc7-builder"                   , [("docker", True), ("dockerImage", "alisw/slc7-builder")]),
+  ((), "build zlib -a slc7_x86-64 --docker"                                            , [("docker", True), ("dockerImage", "alisw/slc7-builder")]),
+  ((), "build zlib --devel-prefix -a slc7_x86-64 --docker"                             , [("docker", True), ("dockerImage", "alisw/slc7-builder"), ("develPrefix", "%s-slc7_x86-64" % os.path.basename(os.getcwd()))]),
+  ((), "build zlib --devel-prefix -a slc7_x86-64 --docker-image someimage"             , [("docker", True), ("dockerImage", "someimage"), ("develPrefix", "%s-slc7_x86-64" % os.path.basename(os.getcwd()))]),
+  ((), "--debug build --force-unknown-architecture --defaults o2 O2"                   , [("debug", True), ("action",  "build"), ("defaults", "o2"), ("pkgname", ["O2"])]),
+  ((), "build --force-unknown-architecture --debug --defaults o2 O2"                   , [("debug", True), ("action",  "build"), ("defaults", "o2"), ("pkgname", ["O2"])]),
+  ((), "init -z test zlib"                                                             , [("configDir", "test/alidist")]),
+  ((), "build --force-unknown-architecture -z test zlib"                               , [("configDir", "alidist")]),
+  ((), "analytics off"                                                                 , [("state", "off")]),
+  ((), "analytics on"                                                                  , [("state", "on")]),
 
   # With ALIBUILD_WORK_DIR and ALIBUILD_CHDIR set
-  (("sw2", ".")    , "build zlib"                         , [("action", "build"), ("workDir", "sw2"), ("referenceSources", "sw2/MIRROR"), ("chdir", ".")]),
-  (("sw3", "mydir"), "init"                               , [("action", "init"), ("workDir", "sw3"), ("referenceSources", "sw3/MIRROR"), ("chdir", "mydir")]),
-  (("sw", ".")     , "clean --chdir mydir2 --work-dir sw4", [("action", "clean"), ("workDir", "sw4"), ("referenceSources", "sw4/MIRROR"), ("chdir", "mydir2")]),
-  (()              , "doctor zlib -C mydir -w sw2"        , [("action", "doctor"), ("workDir", "sw2"), ("chdir", "mydir")]),
-  (()              , "deps zlib --outgraph graph.pdf"     , [("action", "deps"), ("outgraph", "graph.pdf")]),
+  (("sw2", ".")    , "build --force-unknown-architecture zlib"                         , [("action", "build"), ("workDir", "sw2"), ("referenceSources", "sw2/MIRROR"), ("chdir", ".")]),
+  (("sw3", "mydir"), "init"                                                            , [("action", "init"), ("workDir", "sw3"), ("referenceSources", "sw3/MIRROR"), ("chdir", "mydir")]),
+  (("sw", ".")     , "clean --force-unknown-architecture --chdir mydir2 --work-dir sw4", [("action", "clean"), ("workDir", "sw4"), ("referenceSources", "sw4/MIRROR"), ("chdir", "mydir2")]),
+  (()              , "doctor zlib -C mydir -w sw2"                                     , [("action", "doctor"), ("workDir", "sw2"), ("chdir", "mydir")]),
+  (()              , "deps zlib --outgraph graph.pdf"                                  , [("action", "deps"), ("outgraph", "graph.pdf")]),
 ]
 
 GETSTATUSOUTPUT_MOCKS = {
@@ -96,15 +89,13 @@ class ArgsTestCase(unittest.TestCase):
   def test_actionParsing(self, mock_commands):
     mock_commands.getstatusoutput.side_effect = lambda x : GETSTATUSOUTPUT_MOCKS[x]
     for (env, cmd, effects) in CORRECT_BEHAVIOR:
-      env = env if env else ("sw", ".")
-      alibuild_helpers.args.DEFAULT_WORK_DIR = env[0]
-      alibuild_helpers.args.DEFAULT_CHDIR = env[1]
+      (alibuild_helpers.args.DEFAULT_WORK_DIR,
+       alibuild_helpers.args.DEFAULT_CHDIR) = env or ("sw", ".")
       with patch.object(sys, "argv", ["alibuild"] + shlex.split(cmd)):
         args, parser = doParseArgs("ali")
         args = vars(args)
         for k, v in effects:
           self.assertEqual(args[k], v)
-          mock_commands.mock_calls
 
   @mock.patch('alibuild_helpers.args.argparse.ArgumentParser.error')
   def test_failingParsing(self, mock_print):
@@ -115,10 +106,11 @@ class ArgsTestCase(unittest.TestCase):
         self.assertRaises(FakeExit, lambda : doParseArgs("ali"))
         self.assertEqual(mock_print.mock_calls, calls)
 
-  @mock.patch('alibuild_helpers.args.argparse.ArgumentParser.error')
-  def test_validArchitectures(self, mock_error):
-    for x in VALID_ARCHS:
-      self.assertTrue(matchValidArch(x))
+  def test_validArchitectures(self):
+    for arch in VALID_ARCHS:
+      self.assertTrue(matchValidArch(arch))
+    for arch in INVALID_ARCHS:
+      self.assertFalse(matchValidArch(arch))
 
 if __name__ == '__main__':
   unittest.main()

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -7,9 +7,7 @@ except ImportError:
 
 from alibuild_helpers.clean import decideClean, doClean
 
-import mock
 import unittest
-import traceback
 
 REALPATH_WITH_OBSOLETE_FILES = {
   "sw/BUILD/a-latest": "/sw/BUILD/f339115741c6ab9cf291d3210f44bee795c56e16",

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -1,22 +1,20 @@
 from __future__ import print_function
 # Assuming you are using the mock library to ... mock things
 try:
-    from unittest.mock import patch, call  # In Python 3, mock is built-in
+    from unittest import mock  # In Python 3, mock is built-in
 except ImportError:
-    from mock import patch, call  # Python 2
+    import mock  # Python 2
 
 from alibuild_helpers.cmd import execute
 
-import mock
 import unittest
-import traceback
 
 class CmdTestCase(unittest.TestCase):
     @mock.patch("alibuild_helpers.cmd.debug")
     def test_execute(self, mock_debug):
       err = execute("echo foo", mock_debug)
       self.assertEqual(err, 0)
-      self.assertEqual(mock_debug.mock_calls, [call("%s", "foo")])
+      self.assertEqual(mock_debug.mock_calls, [mock.call("%s", "foo")])
       mock_debug.reset_mock()
       err = execute("echoo 2> /dev/null", mock_debug)
       self.assertEqual(err, 127)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,10 +1,12 @@
 from __future__ import print_function
 # Assuming you are using the mock library to ... mock things
 try:
-    from unittest.mock import patch, call, MagicMock  # In Python 3, mock is built-in
+    from unittest import mock
+    from unittest.mock import call, MagicMock  # In Python 3, mock is built-in
     from io import StringIO
 except ImportError:
-    from mock import patch, call, MagicMock  # Python 2
+    import mock
+    from mock import call, MagicMock  # Python 2
     from StringIO import StringIO
 try:
   from collections import OrderedDict
@@ -15,9 +17,7 @@ import sys
 git_mock = MagicMock(partialCloneFilter="--filter=blob:none")
 sys.modules["alibuild_helpers.git"] = git_mock
 from alibuild_helpers.init import doInit,parsePackagesDefinition
-import mock
 import unittest
-import traceback
 from argparse import Namespace
 import os.path as path
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,15 +1,13 @@
 from __future__ import print_function
 # Assuming you are using the mock library to ... mock things
 try:
-    from unittest.mock import patch, call  # In Python 3, mock is built-in
+    from unittest.mock import patch  # In Python 3, mock is built-in
 except ImportError:
-    from mock import patch, call  # Python 2
+    from mock import patch  # Python 2
 
 from alibuild_helpers.log import dieOnError, ProgressPrint
 
-import mock
 import unittest
-import traceback
 from time import sleep
 
 class LogTestCase(unittest.TestCase):

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -1,8 +1,10 @@
 from __future__ import print_function
 # Assumin you are using the mock library to ... mock things
 try:
+    from unittest import mock
     from unittest.mock import patch, call, MagicMock  # In Python 3, mock is built-in
 except ImportError:
+    import mock
     from mock import patch, call, MagicMock  # Python 2
 try:
   from collections import OrderedDict
@@ -14,9 +16,7 @@ from os.path import abspath, join
 from os import getcwd
 
 import re
-import mock
 import unittest
-import traceback
 
 def reference_sources_do_not_exists(x):
   if x.endswith("/aliroot"):


### PR DESCRIPTION
- add a `--force-unknown-architecture` to each command that needs it for tests
- update distro versions in the help message that is shown when an unknown architecture is detected
- add recent Debian versions to the Debian -> Ubuntu conversion table
- fix warnings thrown from `alibuild_helpers.utilities.doDetectArch` due to unclosed files when running `uname -m`
- handle the case where `platform.processor() == ""` but `platform.machine()` is fine -- in that case, we don't need to call `uname -m`
- clean up `args` tests a little, testing invalid architectures as well
- clean up tests' imports, so we don't need `mock` installed when using python3

@ktf, with this PR, I can actually run alibuild's tests on my machine instead of making a docker container each time. I cleaned up a few things on the way. There are lots of small changes in here, would it be better if I split it up or is it OK to review like this?