### PR TITLE
Use Popen.communicate instead of context manager

### DIFF
--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -162,8 +162,11 @@ def doDetectArch(hasOsRelease, osReleaseLines, platformTuple, platformSystem, pl
   processor = platformProcessor
   if not processor:
     # Sometimes platform.processor returns an empty string
-    with subprocess.Popen(("uname", "-m"), stdout=subprocess.PIPE) as p:
-      processor = p.stdout.read().decode("ascii").strip()
+    stdout, _ = subprocess.Popen(
+      ("uname", "-m"), stdout=subprocess.PIPE,
+      stderr=subprocess.DEVNULL, stdin=subprocess.DEVNULL
+    ).communicate()
+    processor = stdout.decode("ascii").strip()
 
   return "{distro}{version}_{machine}".format(
     distro=distribution.lower(), version=version.split(".")[0],


### PR DESCRIPTION
Using Popen as a context manager isn't supported on some older Python versions.

Using `Popen.communicate` ensures that the process gets cleaned up properly when it exits.