### PR TITLE
Fix use of logging function in readDefaults

### DIFF
--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -51,7 +51,7 @@ def doInit(args):
   # Use standard functions supporting overrides and taps. Ignore all disables
   # and system packages as they are irrelevant in this context
   specs = {}
-  defaultsReader = lambda: readDefaults(args.configDir, args.defaults, error, args.architecture)
+  defaultsReader = lambda: readDefaults(args.configDir, args.defaults, lambda msg: error("%s", msg), args.architecture)
   (err, overrides, taps) = parseDefaults([], defaultsReader, debug)
   (_,_,_,validDefaults) = getPackageList(packages=[ p["name"] for p in pkgs ],
                                          specs=specs,

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -8,7 +8,7 @@ from os.path import dirname, exists
 import base64
 import hashlib
 from glob import glob
-from os.path import basename
+from os.path import basename, join
 import sys
 import os
 import re
@@ -224,13 +224,13 @@ def filterByArchitecture(arch, requires):
 def readDefaults(configDir, defaults, error, architecture):
   defaultsFilename = "%s/defaults-%s.sh" % (configDir, defaults)
   if not exists(defaultsFilename):
-    viableDefaults = ["- " + basename(x).replace("defaults-","").replace(".sh", "")
-                      for x in glob("%s/defaults-*.sh" % configDir)]
-    error("Default `%s' does not exists. Viable options:\n%s",
-          defaults or "<no defaults specified>", "\n".join(viableDefaults))
+    error("Default `%s' does not exists. Viable options:\n%s" %
+          (defaults or "<no defaults specified>",
+           "\n".join("- " + basename(x).replace("defaults-", "").replace(".sh", "")
+                     for x in glob(join(configDir, "defaults-*.sh")))))
   err, defaultsMeta, defaultsBody = parseRecipe(getRecipeReader(defaultsFilename))
   if err:
-    error("%s", err)
+    error(err)
     sys.exit(1)
   archDefaults = "%s/defaults-%s.sh" % (configDir, architecture)
   archMeta = {}
@@ -238,7 +238,7 @@ def readDefaults(configDir, defaults, error, architecture):
   if exists(archDefaults):
     err, archMeta, archBody = parseRecipe(getRecipeReader(defaultsFilename))
     if err:
-      error("%s", err)
+      error(err)
       sys.exit(1)
     for x in ["env", "disable", "overrides"]:
       defaultsMeta.setdefault(x, {}).update(archMeta.get(x, {}))


### PR DESCRIPTION
It is passed a function that takes one argument -- normally `argparse.ArgumentParser.error` -- instead of `alibuild_helpers.log.error`. Also patch the one place where this isn't true, in `init.py`.