### PR TITLE
Use remote store by default on Ubuntu 20.04

### DIFF
--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -228,7 +228,7 @@ def finaliseArgs(args, parser, star):
     args.configDir = format(args.configDir, prefix="")
 
     # On selected platforms, caching is active by default
-    if args.architecture == "slc7_x86-64" and not args.preferSystem:
+    if args.architecture in ("slc7_x86-64", "ubuntu2004_x86-64") and not args.preferSystem:
       args.noSystem = True
       if not args.remoteStore:
         args.remoteStore = "https://s3.cern.ch/swift/v1/alibuild-repo"


### PR DESCRIPTION
We build O2 nightly, as for slc7.

Tested in a fresh `alisw/ubuntu2004-builder` container, with aliBuild installed using `pip3`.