### PR TITLE
Override Docker image entrypoint

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -963,7 +963,7 @@ def doBuild(args, parser):
     # will perform the actual build. Otherwise build as usual using bash.
     if args.docker:
       dockerWrapper = (
-        "docker run --rm --user $(id -u):$(id -g) "
+        "docker run --rm --entrypoint= --user $(id -u):$(id -g) "
         "-v {workdir}:/sw -v {scriptDir}/build.sh:/build.sh:ro "
         "-e GIT_REFERENCE_OVERRIDE=/mirror -e WORK_DIR_OVERRIDE=/sw "
         "{mirrorVolume} {develVolumes} {additionalEnv} {additionalVolumes} "

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -453,7 +453,7 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
   return (systemPackages, ownPackages, failedRequirements, validDefaults)
 
 def dockerStatusOutput(cmd, dockerImage=None, executor=getstatusoutput):
-  return executor("docker run --rm {image} bash -c {command}"
+  return executor("docker run --rm --entrypoint= {image} bash -c {command}"
                   .format(image=dockerImage, command=quote(cmd))
                   if dockerImage else cmd)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -182,7 +182,7 @@ class TestUtilities(unittest.TestCase):
   def test_dockerStatusOutput(self, mock_getstatusoutput):
     cmd = dockerStatusOutput(cmd="echo foo", dockerImage="image", executor=mock_getstatusoutput)
     self.assertEqual(mock_getstatusoutput.mock_calls,
-                     [call(u'docker run --rm image bash -c \'echo foo\'')])
+                     [call(u'docker run --rm --entrypoint= image bash -c \'echo foo\'')])
 
   def test_prunePaths(self):
     fake_env = {


### PR DESCRIPTION
If the image has an entrypoint, it will be prepended to our command. We don't want that, so explicitly override it to the empty string.

Tested and working in the fullCI checkers.