### PR TITLE
Store version in alibuild_helpers instead of setup.py

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         run: >-
           GITHUB_TAG=`echo $GITHUB_REF | cut -f3 -d/` ;
           echo $GITHUB_TAG ;
-          perl -p -i -e "s/LAST_TAG/$GITHUB_TAG/g" setup.py
+          perl -p -i -e "s/LAST_TAG/$GITHUB_TAG/g" alibuild_helpers/__init__.py
       - name: Build the python distribution
         run: >-
           python setup.py sdist

--- a/aliBuild
+++ b/aliBuild
@@ -7,6 +7,7 @@ import logging
 import traceback
 
 from os.path import exists, expanduser
+from alibuild_helpers import __version__
 from alibuild_helpers.analytics import decideAnalytics, askForAnalytics, report_screenview, report_exception, report_event
 from alibuild_helpers.analytics import enable_analytics, disable_analytics
 from alibuild_helpers.args import doParseArgs
@@ -15,7 +16,7 @@ from alibuild_helpers.clean import doClean
 from alibuild_helpers.doctor import doDoctor
 from alibuild_helpers.deps import doDeps
 from alibuild_helpers.log import info, warning, debug, logger, error
-from alibuild_helpers.utilities import getVersion, detectArch
+from alibuild_helpers.utilities import detectArch
 from alibuild_helpers.build import doBuild, star
 
 
@@ -58,7 +59,8 @@ def doMain(args, parser):
       exit(1)
 
   if args.action == "version":
-    print("aliBuild version: %s (%s)" % (getVersion(), args.architecture if args.architecture else "unknown"))
+    print("aliBuild version: {version} ({arch})".format(
+      version=__version__, arch=args.architecture or "unknown"))
     sys.exit(0)
 
   if args.action == "doctor":
@@ -90,7 +92,7 @@ if __name__ == "__main__":
   logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 
   os.environ["ALIBUILD_ANALYTICS_ID"] = "UA-77346950-1"
-  os.environ["ALIBUILD_VERSION"] = getVersion()
+  os.environ["ALIBUILD_VERSION"] = __version__
   if args.action == "analytics":
     if args.state == "off":
       disable_analytics()

--- a/alibuild_helpers/__init__.py
+++ b/alibuild_helpers/__init__.py
@@ -1,5 +1,9 @@
-# Dummy file to package build_template.sh
-import sys
+# This file is needed to package build_template.sh.
 
-# remove non-project imports from this module
-del sys
+# Versions should comply with PEP440. For a discussion on single-sourcing the
+# version across setup.py and the project code, see
+# https://packaging.python.org/en/latest/single_source_version.html
+#
+# LAST_TAG is actually a placeholder which will be automatically replaced by
+# the release-alibuild pipeline in jenkins whenever we need a new release.
+__version__ = 'LAST_TAG'

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -216,15 +216,6 @@ def detectArch():
   except:
     return doDetectArch(hasOsRelease, osReleaseLines, ["unknown", "", ""], "", "")
 
-def getVersion():
-  try:
-    import pkg_resources  # part of setuptools
-    return pkg_resources.require("alibuild")[0].version
-  except:
-    cmd = "GIT_DIR=\'%s/.git\' git describe --tags" % dirname(dirname(__file__))
-    err, version = getstatusoutput(cmd)
-    return version if not err else "Unknown version."
-
 def filterByArchitecture(arch, requires):
   for r in requires:
     require, matcher = ":" in r and r.split(":", 1) or (r, ".*")

--- a/script/cibuild
+++ b/script/cibuild
@@ -48,7 +48,7 @@ popd
 # Deploy if this is a tag (do it only for one Python version, not all matrix tests)
 if [[ $TRAVIS_PYTHON_VERSION == 3* && $TRAVIS_TAG && $TRAVIS_PULL_REQUEST == false ]]; then
   pushd alibuild
-    sed -i.deleteme -e "s/LAST_TAG/${TRAVIS_TAG}/g" setup.py
+    sed -i.deleteme -e "s/LAST_TAG/${TRAVIS_TAG}/g" alibuild_helpers/__init__.py
     rm -f *.deleteme
     git clean -fxd
     git diff

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
-import sys
+import alibuild_helpers
 
 here = path.abspath(path.dirname(__file__))
 
@@ -18,13 +18,7 @@ with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
 setup(
     name='alibuild',
 
-    # Versions should comply with PEP440.  For a discussion on single-sourcing
-    # the version across setup.py and the project code, see
-    # https://packaging.python.org/en/latest/single_source_version.html
-    #
-    # LAST_TAG is actually a placeholder which will be automatically replaced by 
-    # the release-alibuild pipeline in jenkins whenever we need a new release.
-    version='LAST_TAG',
+    version=alibuild_helpers.__version__,
 
     description='ALICE Build Tool',
     long_description=long_description,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -13,7 +13,7 @@ from alibuild_helpers.utilities import Hasher
 from alibuild_helpers.utilities import format
 from alibuild_helpers.utilities import asList
 from alibuild_helpers.utilities import dockerStatusOutput
-from alibuild_helpers.utilities import prunePaths, getVersion
+from alibuild_helpers.utilities import prunePaths
 from alibuild_helpers.utilities import to_unicode
 from alibuild_helpers.utilities import resolve_version
 import os
@@ -214,9 +214,6 @@ class TestUtilities(unittest.TestCase):
       self.assertTrue(fake_env_copy["LD_LIBRARY_PATH"] == "/sw/lib")
       self.assertTrue(fake_env_copy["DYLD_LIBRARY_PATH"] == "/sw/lib")
       self.assertTrue(fake_env_copy["ALIBUILD_VERSION"] == "v1.0.0")
-
-  def test_getVersion(self):
-    getVersion()
 
   def test_to_unicode(self):
     t1 = "ताड़िद्दा"


### PR DESCRIPTION
Currently, recent Python 3 versions will throw a `ResourceWarning` from `pkg_resources` when getting the installed version number in unit tests. This patch fixes that.

Storing the version number internally also means we don't need a fallback in case alibuild isn't installed with pip.

The version number is still only stored once. `setup.py` simply gets it from the same place as the `aliBuild` script.