### PR TITLE
Add boto3 remote store

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -8,7 +8,7 @@ from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, error, info, banner, warning
 from alibuild_helpers.log import dieOnError
 from alibuild_helpers.cmd import execute, getStatusOutputBash, BASH
-from alibuild_helpers.utilities import prunePaths
+from alibuild_helpers.utilities import star, prunePaths
 from alibuild_helpers.utilities import format, dockerStatusOutput, parseDefaults, readDefaults
 from alibuild_helpers.utilities import getPackageList
 from alibuild_helpers.utilities import validateDefaults
@@ -16,7 +16,8 @@ from alibuild_helpers.utilities import Hasher
 from alibuild_helpers.utilities import yamlDump
 from alibuild_helpers.utilities import resolve_tag, resolve_version
 from alibuild_helpers.git import partialCloneFilter
-from alibuild_helpers.sync import NoRemoteSync, HttpRemoteSync, S3RemoteSync, RsyncRemoteSync
+from alibuild_helpers.sync import (NoRemoteSync, HttpRemoteSync, S3RemoteSync,
+                                   Boto3RemoteSync, RsyncRemoteSync)
 import yaml
 from alibuild_helpers.workarea import updateReferenceRepoSpec
 from alibuild_helpers.log import logger_handler, LogFormatter, ProgressPrint
@@ -38,9 +39,6 @@ import re
 import shutil
 import sys
 import time
-
-def star():
-  return re.sub("build.*$", "", basename(sys.argv[0]).lower())
 
 def gzip():
   return getstatusoutput("which pigz")[0] and "gzip" or "pigz"
@@ -169,6 +167,9 @@ def doBuild(args, parser):
   elif args.remoteStore.startswith("s3://"):
     syncHelper = S3RemoteSync(args.remoteStore, args.writeStore,
                               args.architecture, args.workDir)
+  elif args.remoteStore.startswith("b3://"):
+    syncHelper = Boto3RemoteSync(args.remoteStore, args.writeStore,
+                                 args.architecture, args.workDir)
   elif args.remoteStore:
     syncHelper = RsyncRemoteSync(args.remoteStore, args.writeStore, args.architecture, args.workDir, "")
   else:

--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -463,9 +463,15 @@ class Boto3RemoteSync:
                           .format(architecture=self.architecture, **spec))
     tar_path = os.path.join(spec["remote_store_path"], tarballNameWithRev)
     link_path = os.path.join(spec["remote_links_path"], tarballNameWithRev)
-    if self._s3_key_exists(tar_path) or self._s3_key_exists(link_path):
+    tar_exists = self._s3_key_exists(tar_path)
+    link_exists = self._s3_key_exists(link_path)
+    if tar_exists and link_exists:
       debug("%s exists on S3 already, not uploading", tarballNameWithRev)
       return
+    if tar_exists or link_exists:
+      warning("%s exists already but %s does not, overwriting!",
+              tar_path if tar_exists else link_path,
+              link_path if tar_exists else tar_path)
     debug("Uploading tarball and symlink for %s %s-%s (%s) to S3",
           p, spec["version"], spec["revision"], spec["remote_revision_hash"])
     self.s3.upload_file(Bucket=self.writeStore, Key=tar_path,

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -31,6 +31,9 @@ if sys.version_info[0] >= 3:
   basestring = None
   unicode = None
 
+def star():
+  return re.sub("build.*$", "", basename(sys.argv[0]).lower())
+
 def is_string(s):
   if sys.version_info[0] >= 3:
     return isinstance(s, str)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 requests
 pyyaml
 distro
+boto3; python_version >= '3.6'
+futures; python_version == '2.7'
+futures; python_version == '2.6'
+argparse; python_version == '2.6'
+ordereddict; python_version == '2.6'

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,12 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
+install_requires = ['pyyaml', 'requests', 'distro']
+# Old setuptools versions (which pip2 uses) don't support range comparisons
+# (like :python_version >= "3.6") in extras_require, so do this ourselves here.
+if sys.version_info >= (3, 6):
+    install_requires.append('boto3')
+
 setup(
     name='alibuild',
 
@@ -77,10 +83,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=['pyyaml',
-                      'requests',
-                      'distro'
-                      ],
+    install_requires=install_requires,
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -62,6 +62,7 @@ class SyncTestCase(unittest.TestCase):
         raise NotImplementedError(url)
 
     @patch("alibuild_helpers.sync.open", new=lambda fn, mode: BytesIO())
+    @patch("os.rename", new=lambda old, new: None)
     @patch("alibuild_helpers.sync.execute", new=lambda cmd, printer=None: 0)
     @patch("alibuild_helpers.sync.warning")
     @patch("alibuild_helpers.sync.error")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,0 +1,212 @@
+import sys
+import unittest
+from io import BytesIO
+
+try:
+    from unittest.mock import patch, MagicMock   # In Python 3, mock is built-in
+except ImportError:
+    from mock import patch, MagicMock   # Python 2
+
+from alibuild_helpers import sync
+
+
+TEST_HASHES = GOOD_HASH, BAD_HASH = ("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                                     "baadf00dbaadf00dbaadf00dbaadf00dbaadf00d")
+DUMMY_SPEC = {"package": "zlib",
+              "version": "v1.2.3",
+              "revision": "1",
+              "remote_store_path": "/sw/path",
+              "remote_links_path": "/sw/links",
+              "remote_tar_hash_dir": "/sw/TARS",
+              "remote_tar_link_dir": "/sw/TARS"}
+
+
+class MockRequest:
+    def __init__(self, j, simulate_err=False):
+        self.j = j
+        self.simulate_err = simulate_err
+        self.status_code = 200 if j else 404
+        self._bytes_left = 123456
+        self.headers = {"content-length": str(self._bytes_left)}
+
+    def raise_for_status(self):
+        return True
+
+    def json(self):
+        return self.j
+
+    def iter_content(self, chunk_size=10):
+        if not self.simulate_err:
+            while self._bytes_left > 0:
+                toread = min(chunk_size, self._bytes_left)
+                yield b"x" * toread
+                self._bytes_left -= toread
+
+
+class SyncTestCase(unittest.TestCase):
+    def setUp(self):
+        self.spec = DUMMY_SPEC.copy()
+
+    def mock_get(self, url, *args, **kw):
+        if "triggers_a_404" in url:
+            return MockRequest(None)
+        if self.spec["remote_store_path"] in url:
+            if self.spec["remote_revision_hash"] == GOOD_HASH:
+                return MockRequest([{"name": "zlib-v1.2.3-1.slc7_x86-64.tar.gz"}])
+            elif self.spec["remote_revision_hash"] == BAD_HASH:
+                return MockRequest([{"name": "zlib-v1.2.3-2.slc7_x86-64.tar.gz"}],
+                                   simulate_err=True)
+        elif self.spec["remote_links_path"] in url:
+            return MockRequest([{"name": "zlib-v1.2.3-1.slc7_x86-64.tar.gz"},
+                                {"name": "zlib-v1.2.3-2.slc7_x86-64.tar.gz"}])
+        raise NotImplementedError(url)
+
+    @patch("alibuild_helpers.sync.open", new=lambda fn, mode: BytesIO())
+    @patch("alibuild_helpers.sync.execute", new=lambda cmd, printer=None: 0)
+    @patch("alibuild_helpers.sync.warning")
+    @patch("alibuild_helpers.sync.error")
+    @patch("alibuild_helpers.sync.get")
+    def test_http_remote(self, mock_get, mock_error, mock_warning):
+        mock_get.side_effect = self.mock_get
+        syncer = sync.HttpRemoteSync(remoteStore="https://localhost/test",
+                                     architecture="osx_x86-64",
+                                     workdir="/sw", insecure=False)
+
+        for test_hash in TEST_HASHES:
+            mock_error.reset_mock()
+            mock_warning.reset_mock()
+            self.spec["remote_revision_hash"] = test_hash
+
+            syncer.syncToLocal("zlib", self.spec)
+
+            if test_hash == GOOD_HASH:
+                mock_error.assert_not_called()
+            elif test_hash == BAD_HASH:
+                # We can't use mock_error.assert_called_once_with because two
+                # PartialDownloadError instances don't compare equal.
+                self.assertEqual(len(mock_error.call_args_list), 1)
+                self.assertEqual(mock_error.call_args_list[0][0][0],
+                                 "GET %s failed: %s")
+                self.assertEqual(mock_error.call_args_list[0][0][1],
+                                 "https://localhost/test//sw/path/"
+                                 "zlib-v1.2.3-2.slc7_x86-64.tar.gz")
+                self.assertIsInstance(mock_error.call_args_list[0][0][2],
+                                      sync.PartialDownloadError)
+                mock_warning.assert_not_called()
+                mock_warning.assert_not_called()
+            else:
+                raise ValueError("unhandled hash")
+
+            syncer.syncToRemote("zlib", self.spec)
+            syncer.syncDistLinksToRemote("/sw/dist")
+
+        self.spec["remote_store_path"] = "/triggers_a_404/path"
+        syncer.syncToLocal("zlib", self.spec)
+        mock_warning.assert_called_once_with(
+            "%s (%s) not fetched: have you tried updating the recipes?",
+            "zlib", BAD_HASH)
+
+    @patch("alibuild_helpers.sync.execute", new=lambda cmd, printer=None: 0)
+    @patch("alibuild_helpers.sync.os")
+    def test_sync(self, mock_os):
+        # file does not exist locally: force download
+        mock_os.path.exists.side_effect = lambda path: False
+        mock_os.path.islink.side_effect = lambda path: False
+        mock_os.path.isfile.side_effect = lambda path: False
+
+        syncers = [
+            sync.NoRemoteSync(),
+            sync.RsyncRemoteSync(remoteStore="ssh://localhost/test",
+                                 writeStore="ssh://localhost/test",
+                                 architecture="osx_x86-64",
+                                 workdir="/sw", rsyncOptions=""),
+            sync.S3RemoteSync(remoteStore="s3://localhost",
+                              writeStore="s3://localhost",
+                              architecture="slc7_x86-64",
+                              workdir="/sw"),
+        ]
+
+        for test_hash in TEST_HASHES:
+            self.spec["remote_revision_hash"] = test_hash
+            for syncer in syncers:
+                syncer.syncToLocal("zlib", self.spec)
+                syncer.syncToRemote("zlib", self.spec)
+                syncer.syncDistLinksToRemote("/sw/dist")
+
+        self.spec["remote_store_path"] = "/triggers_a_404/path"
+        for syncer in syncers:
+            syncer.syncToLocal("zlib", self.spec)
+
+
+class Boto3TestCase(unittest.TestCase):
+    def setUp(self):
+        self.spec = DUMMY_SPEC.copy()
+
+    def mock_s3(self):
+        from botocore.exceptions import ClientError
+
+        def paginate_listdir(Bucket, Delimiter, Prefix):
+            if Prefix == self.spec["remote_store_path"] + "/":
+                if self.spec["remote_revision_hash"] == GOOD_HASH:
+                    return [{"Contents": [{"Key": "zlib-v1.2.3-1.slc7_x86-64.tar.gz"}]}]
+                elif self.spec["remote_revision_hash"] == BAD_HASH:
+                    return [{"Contents": [{"Key": self.spec["remote_store_path"] +
+                                           Delimiter + "zlib-v1.2.3-2.slc7_x86-64.tar.gz"}]}]
+            elif Prefix == self.spec["remote_links_path"] + "/":
+                return [{"Contents": [{"Key": self.spec["remote_links_path"] +
+                                       Delimiter + "zlib-v1.2.3-1.slc7_x86-64.tar.gz"},
+                                      {"Key": self.spec["remote_links_path"] +
+                                       Delimiter + "zlib-v1.2.3-2.slc7_x86-64.tar.gz"}]}]
+            raise NotImplementedError("unknown prefix " + Prefix)
+
+        def head_object(Bucket, Key):
+            if BAD_HASH in Key:
+                err = ClientError()
+                err.response = {"Error": {"Code": "404"}}
+                raise err
+
+        def download_file(Bucket, Key, Filename):
+            self.assertNotIn(BAD_HASH, Key, "tried to fetch nonexistent key")
+
+        def get_object(Bucket, Key):
+            if Key.endswith(".manifest"):
+                return {"Body": MagicMock(iter_lines=lambda: [
+                    b"zlib-v1.2.3-1.slc7_x86-64.tar.gz\t...from manifest\n"])}
+            return {"Body": MagicMock(read=lambda: b"...fetched individually")}
+
+        return MagicMock(
+            get_paginator=lambda method: (MagicMock(paginate=paginate_listdir)
+                                          if method == "list_objects_v2"
+                                          else NotImplemented),
+            head_object=head_object,
+            download_file=download_file,
+            get_object=get_object,
+        )
+
+    @patch("alibuild_helpers.sync.execute", new=lambda cmd, printer=None: 0)
+    @patch("alibuild_helpers.sync.glob.glob", new=lambda path: [])
+    @patch("alibuild_helpers.sync.os.listdir", new=lambda path: [])
+    @patch("alibuild_helpers.sync.Boto3RemoteSync._s3_init", new=lambda _: None)
+    @patch("alibuild_helpers.sync.os")
+    def test_boto3(self, mock_os):
+        if sys.version_info < (3, 6):
+            return
+        # file does not exist locally: force download
+        mock_os.path.exists.side_effect = lambda path: False
+        mock_os.path.islink.side_effect = lambda path: False
+        mock_os.path.isfile.side_effect = lambda path: False
+
+        b3sync = sync.Boto3RemoteSync(
+            remoteStore="b3://localhost", writeStore="b3://localhost",
+            architecture="slc7_x86-64", workdir="/sw")
+        b3sync.s3 = self.mock_s3()
+
+        for test_hash in TEST_HASHES:
+            self.spec["remote_revision_hash"] = test_hash
+            b3sync.syncToLocal("zlib", self.spec)
+            b3sync.syncToRemote("zlib", self.spec)
+            b3sync.syncDistLinksToRemote("/sw/dist")
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Add a new class that fetches tarballs from S3 using boto3. Compared to the existing S3RemoteSync, this doesn't require s3cmd to be installed separately. The new remote also doesn't overwrite existing tarballs and links in S3 (which S3RemoteSync does).

Boto3 only supports Python 3.6+, so the new remote store can only be used under those Python versions.

I've tested fetching (read-only) and uploading (read-write) using the boto3 remote (both work for me).

I've also added new unit tests to cover the boto3 remote (and also extended the previous test to cover the old S3RemoteSync).