### PR TITLE
Don't clone git repo if we're using a prebuilt tarball

### DIFF
--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -81,28 +81,31 @@ fi
 %(referenceStatement)s
 %(partialCloneStatement)s
 
-if [[ ! "$SOURCE0" == '' && "${SOURCE0:0:1}" != "/" ]]; then
-  if [[ ! -d "$SOURCEDIR" ]]; then
-    # In case there is a stale link / file, for whatever reason.
-    rm -rf $SOURCEDIR
-    git clone -n ${GIT_PARTIAL_CLONE_FILTER} ${GIT_REFERENCE:+--reference $GIT_REFERENCE} "$SOURCE0" "$SOURCEDIR"
-    cd $SOURCEDIR
-    git remote set-url --push origin $WRITE_REPO
-    git checkout -f "${GIT_TAG}"
-  else
-    # Folder is already present, but check that it is the right tag
-    cd $SOURCEDIR
-    if ! git checkout "$GIT_TAG"; then
-      # If we can't find the tag, it might be new. Fetch tags and try again.
-      git fetch -f "$SOURCE0" "refs/tags/$GIT_TAG:refs/tags/$GIT_TAG"
-      git checkout "$GIT_TAG"
-    fi
-  fi
-elif [[ ! "$SOURCE0" == '' && "${SOURCE0:0:1}" == "/" ]]; then
-  ln -snf $SOURCE0 $SOURCEDIR
+if [ -z "$CACHED_TARBALL" ]; then
+  case "$SOURCE0" in
+    '')  # SOURCE0 is empty, so just create an empty SOURCEDIR.
+      mkdir -p "$SOURCEDIR" ;;
+    /*)  # SOURCE0 is an absolute path, so just make a symlink there.
+      ln -snf "$SOURCE0" "$SOURCEDIR" ;;
+    *)   # SOURCE0 is a relative path or URL, so clone/checkout the git repo from there.
+      if cd "$SOURCEDIR" 2>/dev/null; then
+        # Folder is already present, but check that it is the right tag
+        if ! git checkout -f "$GIT_TAG"; then
+          # If we can't find the tag, it might be new. Fetch tags and try again.
+          git fetch -f "$SOURCE0" "refs/tags/$GIT_TAG:refs/tags/$GIT_TAG"
+          git checkout -f "$GIT_TAG"
+        fi
+      else
+        # In case there is a stale link / file, for whatever reason.
+        rm -rf "$SOURCEDIR"
+        git clone -n $GIT_PARTIAL_CLONE_FILTER ${GIT_REFERENCE:+--reference "$GIT_REFERENCE"} "$SOURCE0" "$SOURCEDIR"
+        cd "$SOURCEDIR"
+        git remote set-url --push origin "$WRITE_REPO"
+        git checkout -f "$GIT_TAG"
+      fi ;;
+  esac
 fi
 
-mkdir -p "$SOURCEDIR"
 cd "$BUILDDIR"
 
 # Actual build script, as defined in the recipe


### PR DESCRIPTION
Cloning or checking out the associated git repo is unnecessary if we're just reusing a prebuilt tarball. Skipping this step can save significant build time, especially for large packages like GCC or Clang.

To be tested.

PR 1/n replacing #683.