### PR TITLE
Do not use --filter blob:none for aliBuild init

### DIFF
--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -3,7 +3,6 @@ from alibuild_helpers.utilities import format
 from alibuild_helpers.utilities import parseRecipe, getPackageList, getRecipeReader, parseDefaults, readDefaults, validateDefaults
 from alibuild_helpers.log import debug, error, warning, banner, info
 from alibuild_helpers.log import dieOnError
-from alibuild_helpers.git import partialCloneFilter
 from alibuild_helpers.workarea import updateReferenceRepoSpec
 
 from os.path import abspath, basename, join
@@ -39,8 +38,7 @@ def doInit(args):
   if path.exists(args.configDir):
     warning("using existing recipes from %s", args.configDir)
   else:
-    cmd = format("git clone --origin upstream %(pcf)s %(repo)s%(branch)s %(cd)s",
-                 pcf=partialCloneFilter,
+    cmd = format("git clone --origin upstream %(repo)s%(branch)s %(cd)s",
                  repo=args.dist["repo"] if ":" in args.dist["repo"] else "https://github.com/%s" % args.dist["repo"],
                  branch=" -b "+args.dist["ver"] if args.dist["ver"] else "",
                  cd=args.configDir)
@@ -86,9 +84,8 @@ def doInit(args):
     debug("cloning %s%s for development", spec["package"], " version "+p["ver"] if p["ver"] else "")
 
     updateReferenceRepoSpec(args.referenceSources, spec["package"], spec, True)
-    cmd = format("git clone --origin upstream %(pcf)s %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
+    cmd = format("git clone --origin upstream %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
                  "cd %(cd)s && git remote set-url --push upstream %(writeRepo)s",
-                 pcf=partialCloneFilter,
                  readRepo=spec["source"],
                  writeRepo=writeRepo,
                  branch=" -b "+p["ver"] if p["ver"] else "",

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -83,7 +83,7 @@ def doInit(args):
     p["ver"] = p["ver"] if p["ver"] else spec.get("tag", spec["version"])
     debug("cloning %s%s for development", spec["package"], " version "+p["ver"] if p["ver"] else "")
 
-    updateReferenceRepoSpec(args.referenceSources, spec["package"], spec, True)
+    updateReferenceRepoSpec(args.referenceSources, spec["package"], spec, True, False)
     cmd = format("git clone --origin upstream %(readRepo)s%(branch)s --reference %(refSource)s %(cd)s && " +
                  "cd %(cd)s && git remote set-url --push upstream %(writeRepo)s",
                  readRepo=spec["source"],

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -106,7 +106,7 @@ class InitTestCase(unittest.TestCase):
         architecture = "slc7_x86-64"
       )
       doInit(args)
-      mock_execute.assert_called_with("git clone --origin upstream --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push upstream https://github.com/alisw/AliRoot")
+      mock_execute.assert_called_with("git clone --origin upstream https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push upstream https://github.com/alisw/AliRoot")
       self.assertEqual(mock_execute.mock_calls, CLONE_EVERYTHING)
       mock_path.exists.assert_has_calls([call('.'), call('/sw/MIRROR'), call('/alidist'), call('./AliRoot')])
 
@@ -115,7 +115,7 @@ class InitTestCase(unittest.TestCase):
       mock_path.reset_mock()
       args.fetchRepos = True
       doInit(args)
-      mock_execute.assert_called_with("git clone --origin upstream --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push upstream https://github.com/alisw/AliRoot")
+      mock_execute.assert_called_with("git clone --origin upstream https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push upstream https://github.com/alisw/AliRoot")
       self.assertEqual(mock_execute.mock_calls, CLONE_EVERYTHING)
       mock_path.exists.assert_has_calls([call('.'), call('/sw/MIRROR'), call('/alidist'), call('./AliRoot')])
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -41,8 +41,8 @@ def dummy_exists(x):
   return False
 
 CLONE_EVERYTHING = [
- call(u'git clone --origin upstream --filter=blob:none https://github.com/alisw/alidist -b master /alidist'),
- call(u'git clone --origin upstream --filter=blob:none https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push upstream https://github.com/alisw/AliRoot')
+ call(u'git clone --origin upstream https://github.com/alisw/alidist -b master /alidist'),
+ call(u'git clone --origin upstream https://github.com/alisw/AliRoot -b v5-08-00 --reference /sw/MIRROR/aliroot ./AliRoot && cd ./AliRoot && git remote set-url --push upstream https://github.com/alisw/AliRoot')
 ]
 
 class InitTestCase(unittest.TestCase):


### PR DESCRIPTION
Using:

```
--filter blob:none --origin upstream
```

does not work on Ubuntu 18.04 (16% of our users). Given in any case if you do aliBuild init most likely you want a complete repository, I guess it's ok to disable the partial clone for now.