### PR TITLE
Remove unused argument for extra rsync options

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -217,7 +217,7 @@ def doBuild(args, parser):
     syncHelper = Boto3RemoteSync(args.remoteStore, args.writeStore,
                                  args.architecture, args.workDir)
   elif args.remoteStore:
-    syncHelper = RsyncRemoteSync(args.remoteStore, args.writeStore, args.architecture, args.workDir, "")
+    syncHelper = RsyncRemoteSync(args.remoteStore, args.writeStore, args.architecture, args.workDir)
   else:
     syncHelper = NoRemoteSync()
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -126,7 +126,7 @@ class SyncTestCase(unittest.TestCase):
             sync.RsyncRemoteSync(remoteStore="ssh://localhost/test",
                                  writeStore="ssh://localhost/test",
                                  architecture=ARCHITECTURE,
-                                 workdir="/sw", rsyncOptions=""),
+                                 workdir="/sw"),
             sync.S3RemoteSync(remoteStore="s3://localhost",
                               writeStore="s3://localhost",
                               architecture="slc7_x86-64",


### PR DESCRIPTION
Everything passes the empty string along anyway, and it's not user-configurable
at all.