### PR TITLE
Improve command-line argument documentation

### DIFF
--- a/alibuild_helpers/doctor.py
+++ b/alibuild_helpers/doctor.py
@@ -8,10 +8,9 @@ except ImportError:
 import logging
 from alibuild_helpers.log import debug, error, banner, info, success, warning
 from alibuild_helpers.log import logger
-from alibuild_helpers.utilities import getPackageList, format, detectArch, parseDefaults, readDefaults, validateDefaults
+from alibuild_helpers.utilities import getPackageList, parseDefaults, readDefaults, validateDefaults
 from alibuild_helpers.utilities import dockerStatusOutput
 from alibuild_helpers.cmd import getStatusOutputBash
-import subprocess
 
 def prunePaths(workDir):
   for x in ["PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"]:
@@ -71,31 +70,6 @@ def systemInfo():
     err,out = getstatusoutput("cat "+f)
     if not err:
       debug("%s:\n%s", f, out)
-
-def doctorArgParser(parser):
-  parser.add_argument("-a", "--architecture", help="force architecture",
-                      dest="architecture", default=detectArch())
-  parser.add_argument("-c", "--config", help="path to alidist",
-                      dest="configDir", default="alidist")
-  parser.add_argument("-w", "--work-dir", help="path to work dir",
-                      dest="workDir", default="workDir")
-  parser.add_argument("--defaults", default="release",
-                      dest="defaults", help="Specify default to use")
-  parser.add_argument("--disable", dest="disable", default=[],
-                      metavar="PACKAGE", action="append",
-                      help="Do not build PACKAGE and all its (unique) dependencies.")
-  parser.add_argument("--always-prefer-system", dest="preferSystem", default=False,
-                      action="store_true", help="Always use system packages when compatible")
-  parser.add_argument("--no-system", dest="noSystem", default=False,
-                      action="store_true", help="Never use system packages")
-  parser.add_argument("packages", nargs="+", help="Package to test",
-                      default=[])
-  parser.add_argument("--docker", dest="docker", action="store_true", default=False)
-  parser.add_argument("--docker-image", dest="dockerImage",
-                      help="Image to use in case you build with docker (implies --docker)")
-  parser.add_argument("--chdir", "-C", help="Change to the specified directory first",
-                      metavar="DIR", dest="chdir", default=os.environ.get("ALIBUILD_CHDIR") or ".")
-  return parser
 
 def doDoctor(args, parser):
   if not exists(args.configDir):

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -19,7 +19,7 @@ import traceback
 import shlex
 
 if (sys.version_info[0] >= 3):
-  BUILD_MISSING_PKG_ERROR = "the following arguments are required: pkgname"
+  BUILD_MISSING_PKG_ERROR = "the following arguments are required: PACKAGE"
   ANALYTICS_MISSING_STATE_ERROR = "the following arguments are required: state"
 else:
   BUILD_MISSING_PKG_ERROR = "too few arguments"
@@ -34,7 +34,6 @@ PARSER_ERRORS = {
   "builda --force-unknown-architecture zlib" : [call("argument action: invalid choice: 'builda' (choose from 'analytics', 'architecture', 'build', 'clean', 'deps', 'doctor', 'init', 'version')")],
   "build --force-unknown-architecture zlib --no-system --always-prefer-system" : [call('argument --always-prefer-system: not allowed with argument --no-system')],
   "build zlib --architecture foo": ARCHITECTURE_ERROR,
-  "clean --architecture foo": ARCHITECTURE_ERROR,
   "build --force-unknown-architecture zlib --remote-store rsync://test1.local/::rw --write-store rsync://test2.local/::rw ": [call('cannot specify ::rw and --write-store at the same time')],
   "build zlib -a osx_x86-64 --docker-image foo": [call('cannot use `-a osx_x86-64` and --docker')],
   "analytics": [call(ANALYTICS_MISSING_STATE_ERROR)]
@@ -51,7 +50,7 @@ CORRECT_BEHAVIOR = [
   ((), "build --force-unknown-architecture zlib"                                       , [("action", "build"), ("workDir", "sw"), ("referenceSources", "sw/MIRROR")]),
   ((), "init"                                                                          , [("action", "init"), ("workDir", "sw"), ("referenceSources", "sw/MIRROR")]),
   ((), "version"                                                                       , [("action", "version")]),
-  ((), "clean --force-unknown-architecture"                                            , [("action", "clean"), ("workDir", "sw"), ("referenceSources", "sw/MIRROR")]),
+  ((), "clean"                                                                         , [("action", "clean"), ("workDir", "sw")]),
   ((), "build --force-unknown-architecture -j 10 zlib"                                 , [("action", "build"), ("jobs", 10), ("pkgname", ["zlib"])]),
   ((), "build --force-unknown-architecture -j 10 zlib --disable gcc --disable foo"     , [("disable", ["gcc", "foo"])]),
   ((), "build --force-unknown-architecture -j 10 zlib --disable gcc --disable foo,bar" , [("disable", ["gcc", "foo", "bar"])]),
@@ -76,7 +75,7 @@ CORRECT_BEHAVIOR = [
   # With ALIBUILD_WORK_DIR and ALIBUILD_CHDIR set
   (("sw2", ".")    , "build --force-unknown-architecture zlib"                         , [("action", "build"), ("workDir", "sw2"), ("referenceSources", "sw2/MIRROR"), ("chdir", ".")]),
   (("sw3", "mydir"), "init"                                                            , [("action", "init"), ("workDir", "sw3"), ("referenceSources", "sw3/MIRROR"), ("chdir", "mydir")]),
-  (("sw", ".")     , "clean --force-unknown-architecture --chdir mydir2 --work-dir sw4", [("action", "clean"), ("workDir", "sw4"), ("referenceSources", "sw4/MIRROR"), ("chdir", "mydir2")]),
+  (("sw", ".")     , "clean --chdir mydir2 --work-dir sw4"                             , [("action", "clean"), ("workDir", "sw4"), ("chdir", "mydir2")]),
   (()              , "doctor zlib -C mydir -w sw2"                                     , [("action", "doctor"), ("workDir", "sw2"), ("chdir", "mydir")]),
   (()              , "deps zlib --outgraph graph.pdf"                                  , [("action", "deps"), ("outgraph", "graph.pdf")]),
 ]


### PR DESCRIPTION
Lots of command-line options had no documentation at all when running `aliBuild <command> --help`. This PR fixes that and makes the existing help text more consistent across commands.

I changed a few small parts of argument parsing:

- I removed the ability to specify a `%(prefix)s` in `--config-dir` for `aliBuild build` -- it was always substituted with the empty string.
  - `aliBuild init` still has this ability, and it substitutes the argument to its `--devel-prefix` option for `%(prefix)s`. Is this useful or can it be removed as well? It seems like `aliBuild build` may have done this in the past as well, but not any more.
  - The meanings of `-z`/`--devel-prefix` in `aliBuild build` and `aliBuild init` have apparently diverged significantly. See above -- is the option still needed for `aliBuild init`?
- `aliBuild clean` now accepts any architecture, even if unsupported -- my reasoning is that if we're cleaning up for a specific architecture, we previously built something for that architecture, so the user wants to use it. I'd say having to use `--force-unknown-architecture` is more of a hassle in this case.

I also updated the synopsis of `aliBuild build` in the user documentation, as it was out of date.