### PR TITLE
Get alibuild version directly, instead of calling pip

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -4,6 +4,7 @@ try:
   from commands import getstatusoutput
 except ImportError:
   from subprocess import getstatusoutput
+from alibuild_helpers import __version__
 from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, error, info, banner, warning
 from alibuild_helpers.log import dieOnError
@@ -52,12 +53,8 @@ def readHashFile(fn):
     return "0"
 
 def getDirectoryHash(d):
-  if exists(join(d, ".git")):
-    err, out = getstatusoutput("GIT_DIR=%s/.git git rev-parse HEAD" % d)
-    dieOnError(err, "Impossible to find reference for %s " % d)
-  else:
-    err, out = getstatusoutput("pip --disable-pip-version-check show alibuild | grep -e \"^Version:\" | sed -e 's/.* //'")
-    dieOnError(err, "Impossible to find reference for %s " % d)
+  err, out = getstatusoutput("cd %s && git rev-parse HEAD" % d)
+  dieOnError(err, "Impossible to find reference for %s" % d)
   return out
 
 # Creates a directory in the store which contains symlinks to the package
@@ -272,8 +269,7 @@ def doBuild(args, parser):
   debug("Building for architecture %s", args.architecture)
   debug("Number of parallel builds: %d", args.jobs)
   debug("Using %sBuild from %sbuild@%s recipes in %sdist@%s",
-        star(), star(), getDirectoryHash(dirname(__file__)), star(),
-        os.environ["ALIBUILD_ALIDIST_HASH"])
+        star(), star(), __version__, star(), os.environ["ALIBUILD_ALIDIST_HASH"])
 
   def get_status(cmd):
     if dockerImage is not None:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -106,8 +106,7 @@ def dummy_getstatusoutput(x):
     if re.match("(mkdir -p|ln -snf) [^;]+(;ln -snf [^;]+)*$", x):
         return (0, "")
     return {
-        "GIT_DIR=/alidist/.git git rev-parse HEAD": (0, "6cec7b7b3769826219dfa85e5daa6de6522229a0"),
-        'pip --disable-pip-version-check show alibuild | grep -e "^Version:" | sed -e \'s/.* //\'': (0, "v1.5.0"),
+        "cd /alidist && git rev-parse HEAD": (0, "6cec7b7b3769826219dfa85e5daa6de6522229a0"),
         'which pigz': (1, ""),
         'tar --ignore-failed-read -cvvf /dev/null /dev/zero': (0, ""),
         'GIT_DIR=/alidist/.git git symbolic-ref -q HEAD': (0, "master")


### PR DESCRIPTION
The version is only shown once, before starting the build. Instead of calling pip (and getting error messages more often than not), use the version number stored in `alibuild_helpers.__version__` instead. This brings it in line with what `aliBuild version` displays.