### PR TITLE
Create links directory for rsync remote

### DIFF
--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -222,6 +222,7 @@ class RsyncRemoteSync:
     debug("Updating remote store for package %s with hashes %s", p,
           ", ".join(spec["remote_hashes"]))
     err = execute("""\
+    mkdir -p {workDir}/{linksPath}
     rsync -rlvW --delete {remoteStore}/{linksPath}/ {workDir}/{linksPath}/ || :
     for storePath in {storePaths}; do
       # Only get the first matching tarball. If there are multiple with the


### PR DESCRIPTION
Sometimes, this isn't created beforehand, causing errors when syncing symlinks from an `rsync://` remote store.