### PR TITLE
Use only single Docker container for running system checks

### DIFF
--- a/alibuild_helpers/analytics.py
+++ b/alibuild_helpers/analytics.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 import os, subprocess, sys
-try:
-  from commands import getstatusoutput
-except ImportError:
-  from subprocess import getstatusoutput
-from alibuild_helpers.log import debug, banner
 from os.path import exists, expanduser
 from os import unlink
+
+from alibuild_helpers.cmd import getstatusoutput
+from alibuild_helpers.log import debug, banner
+
 
 def generate_analytics_id():
   getstatusoutput("mkdir -p  ~/.config/alibuild")

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -1,17 +1,13 @@
 from os.path import abspath, exists, basename, dirname, join, realpath
 from os import makedirs, unlink, readlink, rmdir
-try:
-  from commands import getstatusoutput
-except ImportError:
-  from subprocess import getstatusoutput
 from alibuild_helpers import __version__
 from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, error, info, banner, warning
 from alibuild_helpers.log import dieOnError
-from alibuild_helpers.cmd import execute, getStatusOutputBash, BASH
+from alibuild_helpers.cmd import execute, getstatusoutput, getStatusOutputBash, dockerStatusOutput, BASH
 from alibuild_helpers.utilities import star, prunePaths
 from alibuild_helpers.utilities import resolve_store_path
-from alibuild_helpers.utilities import format, dockerStatusOutput, parseDefaults, readDefaults
+from alibuild_helpers.utilities import format, parseDefaults, readDefaults
 from alibuild_helpers.utilities import getPackageList
 from alibuild_helpers.utilities import validateDefaults
 from alibuild_helpers.utilities import Hasher

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -284,7 +284,6 @@ def doBuild(args, parser):
                                                                         architecture            = args.architecture,
                                                                         disable                 = args.disable,
                                                                         defaults                = args.defaults,
-                                                                        dieOnError              = dieOnError,
                                                                         performPreferCheck      = lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage, executor=getStatusOutputBash),
                                                                         performRequirementCheck = lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage, executor=getStatusOutputBash),
                                                                         performValidateDefaults = lambda spec : validateDefaults(spec, args.defaults),

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -4,7 +4,7 @@ from alibuild_helpers import __version__
 from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, error, info, banner, warning
 from alibuild_helpers.log import dieOnError
-from alibuild_helpers.cmd import execute, getstatusoutput, getStatusOutputBash, DockerRunner, BASH
+from alibuild_helpers.cmd import execute, getstatusoutput, DockerRunner, BASH
 from alibuild_helpers.utilities import star, prunePaths
 from alibuild_helpers.utilities import resolve_store_path
 from alibuild_helpers.utilities import format, parseDefaults, readDefaults
@@ -377,7 +377,7 @@ def doBuild(args, parser):
          specs[p]["source"] = join(os.getcwd(), specs[p]["package"])
          cmd = "git ls-remote --heads --tags %s" % specs[p]["source"]
       debug("Executing %s", cmd)
-      err, output = getStatusOutputBash(cmd)
+      err, output = getstatusoutput(cmd)
       if err:
         raise RuntimeError("Error on '%s': %s" % (cmd, output))
       specs[p]["git_refs"] = {git_ref: git_hash for git_hash, sep, git_ref in

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -998,9 +998,8 @@ def doBuild(args, parser):
         "-v {workdir}:/sw -v {scriptDir}/build.sh:/build.sh:ro "
         "-e GIT_REFERENCE_OVERRIDE=/mirror -e WORK_DIR_OVERRIDE=/sw "
         "{mirrorVolume} {develVolumes} {additionalEnv} {additionalVolumes} "
-        "{overrideSource} {extraArgs} {image} {bash} -ex /build.sh"
+        "{overrideSource} {extraArgs} {image} bash -ex /build.sh"
       ).format(
-        bash=quote(BASH),
         image=quote(dockerImage),
         workdir=quote(abspath(args.workDir)),
         scriptDir=quote(scriptDir),

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -1,20 +1,37 @@
+import subprocess
+import sys
 try:
   from commands import getstatusoutput
 except ImportError:
   from subprocess import getstatusoutput
+try:
+  from shlex import quote  # Python 3.3+
+except ImportError:
+  from pipes import quote  # Python 2.7
+
 from alibuild_helpers.log import debug
-from alibuild_helpers.utilities import is_string, to_unicode
-import subprocess
 
 BASH = "bash" if getstatusoutput("/bin/bash --version")[0] else "/bin/bash"
 
+# Keep the linter happy
+if sys.version_info[0] >= 3:
+  basestring = None
+
+
+def is_string(s):
+  if sys.version_info[0] >= 3:
+    return isinstance(s, str)
+  return isinstance(s, basestring)
+
+
 def execute(command, printer=debug):
-  popen = subprocess.Popen(command, shell=is_string(command), stdout=subprocess.PIPE)
+  popen = subprocess.Popen(command, shell=is_string(command), stdout=subprocess.PIPE,
+                           universal_newlines=True)
   lines_iterator = iter(popen.stdout.readline, "")
   for line in lines_iterator:
     if not line: break
-    printer("%s", to_unicode(line).strip("\n"))
-  out = to_unicode(popen.communicate()[0]).strip("\n")
+    printer("%s", line.strip("\n"))
+  out = popen.communicate()[0].strip("\n")
   if out:
     printer(out)
   return popen.returncode
@@ -22,6 +39,12 @@ def execute(command, printer=debug):
 def getStatusOutputBash(command):
   assert is_string(command), "only strings accepted as command"
   popen = subprocess.Popen([ BASH, "-c", command ], shell=False,
-                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-  out = to_unicode(popen.communicate()[0])
+                           stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                           universal_newlines=True)
+  out = popen.communicate()[0]
   return (popen.returncode, out)
+
+def dockerStatusOutput(cmd, dockerImage=None, executor=getstatusoutput):
+  return executor("docker run --rm --entrypoint= {image} bash -c {command}"
+                  .format(image=dockerImage, command=quote(cmd))
+                  if dockerImage else cmd)

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -1,5 +1,5 @@
 import sys
-from subprocess import Popen, PIPE, STDOUT
+from subprocess import Popen, PIPE
 try:
   from commands import getstatusoutput
 except ImportError:
@@ -45,14 +45,6 @@ def execute(command, printer=debug):
   if out:
     printer(out)
   return popen.returncode
-
-
-def getStatusOutputBash(command):
-  assert is_string(command), "only strings accepted as command"
-  popen = Popen([BASH, "-c", command], shell=False, stdout=PIPE, stderr=STDOUT,
-                universal_newlines=True)
-  out, _ = popen.communicate()
-  return popen.returncode, out
 
 
 class DockerRunner:

--- a/alibuild_helpers/deps.py
+++ b/alibuild_helpers/deps.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 
 from __future__ import print_function
-from alibuild_helpers.log import debug, error, banner, info, success, warning, dieOnError
-from alibuild_helpers.utilities import parseDefaults, readDefaults, getPackageList, validateDefaults, dockerStatusOutput, format
-from alibuild_helpers.cmd import getStatusOutputBash, execute
+from alibuild_helpers.log import debug, error, info, dieOnError
+from alibuild_helpers.utilities import parseDefaults, readDefaults, getPackageList, validateDefaults, format
+from alibuild_helpers.cmd import getStatusOutputBash, dockerStatusOutput, execute
 from tempfile import NamedTemporaryFile
 from os import remove
 

--- a/alibuild_helpers/deps.py
+++ b/alibuild_helpers/deps.py
@@ -31,7 +31,6 @@ def doDeps(args, parser):
                    architecture            = args.architecture,
                    disable                 = args.disable,
                    defaults                = args.defaults,
-                   dieOnError              = dieOnError,
                    performPreferCheck      = lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage, executor = getStatusOutputBash),
                    performRequirementCheck = lambda pkg, cmd : dockerStatusOutput(cmd, dockerImage, executor = getStatusOutputBash),
                    performValidateDefaults = lambda spec : validateDefaults(spec, args.defaults),

--- a/alibuild_helpers/doctor.py
+++ b/alibuild_helpers/doctor.py
@@ -1,16 +1,11 @@
 #!/usr/bin/env python
 import os, re, sys
 from os.path import exists, abspath, expanduser
-try:
-  from commands import getstatusoutput
-except ImportError:
-  from subprocess import getstatusoutput
 import logging
 from alibuild_helpers.log import debug, error, banner, info, success, warning
 from alibuild_helpers.log import logger
 from alibuild_helpers.utilities import getPackageList, parseDefaults, readDefaults, validateDefaults
-from alibuild_helpers.utilities import dockerStatusOutput
-from alibuild_helpers.cmd import getStatusOutputBash
+from alibuild_helpers.cmd import getstatusoutput, getStatusOutputBash, dockerStatusOutput
 
 def prunePaths(workDir):
   for x in ["PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"]:

--- a/alibuild_helpers/doctor.py
+++ b/alibuild_helpers/doctor.py
@@ -129,8 +129,6 @@ def doDoctor(args, parser):
   systemInfo()
 
   specs = {}
-  def unreachable():
-    assert(False)
   defaultsReader = lambda : readDefaults(args.configDir, args.defaults, parser.error, args.architecture)
   (err, overrides, taps) = parseDefaults(args.disable, defaultsReader, info)
   if err:
@@ -151,7 +149,6 @@ def doDoctor(args, parser):
                                                             architecture            = args.architecture,
                                                             disable                 = args.disable,
                                                             defaults                = args.defaults,
-                                                            dieOnError              = lambda x, y : unreachable,
                                                             performPreferCheck      = lambda pkg, cmd : checkPreferSystem(pkg, cmd, homebrew_replacement, dockerImage),
                                                             performRequirementCheck = lambda pkg, cmd : checkRequirements(pkg, cmd, homebrew_replacement, dockerImage),
                                                             performValidateDefaults = performValidateDefaults,

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -1,10 +1,9 @@
-try:
-  from commands import getstatusoutput
-except ImportError:
-  from subprocess import getstatusoutput
+from alibuild_helpers.cmd import getstatusoutput
+
 
 def __partialCloneFilter():
   err, out = getstatusoutput("LANG=C git clone --filter=blob:none 2>&1 | grep 'unknown option'")
   return err and "--filter=blob:none" or ""
+
 
 partialCloneFilter = __partialCloneFilter()

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -58,7 +58,6 @@ def doInit(args):
                                          architecture="",
                                          disable=[],
                                          defaults=args.defaults,
-                                         dieOnError=dieOnError,
                                          performPreferCheck=lambda *x, **y: (1, ""),
                                          performRequirementCheck=lambda *x, **y: (0, ""),
                                          performValidateDefaults=lambda spec : validateDefaults(spec, args.defaults),

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -1,11 +1,10 @@
 from alibuild_helpers.cmd import execute
-from alibuild_helpers.utilities import format
-from alibuild_helpers.utilities import parseRecipe, getPackageList, getRecipeReader, parseDefaults, readDefaults, validateDefaults
+from alibuild_helpers.utilities import format, parseRecipe, getPackageList, getRecipeReader, parseDefaults, readDefaults, validateDefaults
 from alibuild_helpers.log import debug, error, warning, banner, info
 from alibuild_helpers.log import dieOnError
 from alibuild_helpers.workarea import updateReferenceRepoSpec
 
-from os.path import abspath, basename, join
+from os.path import join
 import os.path as path
 import os, sys
 try:

--- a/alibuild_helpers/log.py
+++ b/alibuild_helpers/log.py
@@ -1,10 +1,8 @@
 import logging
 import sys
 import re
-from os import getenv
-import socket, time
+import time
 import datetime
-from alibuild_helpers.utilities import format, to_unicode
 
 debug, error, warning, info, success = (None, None, None, None, None)
 
@@ -22,20 +20,19 @@ class LogFormatter(logging.Formatter):
                           logging.CRITICAL: "\033[1;37;41m",
                           logging.SUCCESS:  "\033[1;32m" } if sys.stdout.isatty() else {}
   def format(self, record):
-    record.msg = to_unicode(record.msg % record.args)
+    record.msg = record.msg % record.args
     if record.levelno == logging.BANNER and sys.stdout.isatty():
       lines = record.msg.split("\n")
       return "\n\033[1;34m==>\033[m \033[1m%s\033[m" % lines[0] + \
-             "".join([ "\n    \033[1m%s\033[m" % x for x in lines[1:] ])
+             "".join("\n    \033[1m%s\033[m" % x for x in lines[1:])
     elif record.levelno == logging.INFO or record.levelno == logging.BANNER:
       return record.msg
-    return "\n".join([ format(self.fmtstr,
-                              asctime = datetime.datetime.now().strftime("%Y-%m-%d@%H:%M:%S"),
-                              levelname=self.LEVEL_COLORS.get(record.levelno, self.COLOR_RESET) +
-                                        record.levelname +
-                                        self.COLOR_RESET,
-                              message=x)
-                       for x in record.msg.split("\n") ])
+    return "\n".join(self.fmtstr % {
+      "asctime": datetime.datetime.now().strftime("%Y-%m-%d@%H:%M:%S"),
+      "levelname": (self.LEVEL_COLORS.get(record.levelno, self.COLOR_RESET) +
+                    record.levelname + self.COLOR_RESET),
+      "message": x,
+    } for x in record.msg.split("\n"))
 
 class ProgressPrint:
   def __init__(self, begin_msg=""):

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -13,7 +13,7 @@ try:
 except ImportError:
   from ordereddict import OrderedDict
 
-from alibuild_helpers.cmd import getstatusoutput
+from alibuild_helpers.cmd import getoutput, getstatusoutput
 
 
 class SpecError(Exception):
@@ -179,11 +179,7 @@ def doDetectArch(hasOsRelease, osReleaseLines, platformTuple, platformSystem, pl
   processor = platformProcessor
   if not processor:
     # Sometimes platform.processor returns an empty string
-    stdout, _ = subprocess.Popen(
-      ("uname", "-m"), stdout=subprocess.PIPE,
-      stderr=None, stdin=None
-    ).communicate()
-    processor = stdout.decode("ascii").strip()
+    processor = getoutput(("uname", "-m")).strip()
 
   return "{distro}{version}_{machine}".format(
     distro=distribution, version=version.split(".")[0],

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-import subprocess, yaml
+import yaml
 from os.path import exists
 import hashlib
 from glob import glob
@@ -14,6 +14,7 @@ except ImportError:
   from ordereddict import OrderedDict
 
 from alibuild_helpers.cmd import getoutput, getstatusoutput
+from alibuild_helpers.log import dieOnError
 
 
 class SpecError(Exception):
@@ -353,7 +354,7 @@ def parseDefaults(disable, defaultsGetter, log):
   return (None, overrides, taps)
 
 def getPackageList(packages, specs, configDir, preferSystem, noSystem,
-                   architecture, disable, defaults, dieOnError, performPreferCheck, performRequirementCheck,
+                   architecture, disable, defaults, performPreferCheck, performRequirementCheck,
                    performValidateDefaults, overrides, taps, log):
   systemPackages = set()
   ownPackages = set()

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -2,10 +2,6 @@ from alibuild_helpers.log import dieOnError, debug
 from alibuild_helpers.cmd import execute
 from alibuild_helpers.git import partialCloneFilter
 from os.path import dirname, abspath
-try:
-  from commands import getstatusoutput
-except ImportError:
-  from subprocess import getstatusoutput
 from alibuild_helpers.utilities import format
 
 import os

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -83,6 +83,7 @@ GETSTATUSOUTPUT_MOCKS = {
 }
 
 class ArgsTestCase(unittest.TestCase):
+  @mock.patch("alibuild_helpers.utilities.getoutput", new=lambda cmd: "x86_64")   # for uname -m
   @mock.patch('alibuild_helpers.args.commands')
   def test_actionParsing(self, mock_commands):
     mock_commands.getstatusoutput.side_effect = lambda x : GETSTATUSOUTPUT_MOCKS[x]
@@ -95,6 +96,7 @@ class ArgsTestCase(unittest.TestCase):
         for k, v in effects:
           self.assertEqual(args[k], v)
 
+  @mock.patch("alibuild_helpers.utilities.getoutput", new=lambda cmd: "x86_64")   # for uname -m
   @mock.patch('alibuild_helpers.args.argparse.ArgumentParser.error')
   def test_failingParsing(self, mock_print):
     mock_print.side_effect = FakeExit("raised")

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -9,13 +9,11 @@ except ImportError:
 
 import alibuild_helpers.args
 from alibuild_helpers.args import doParseArgs, matchValidArch, finaliseArgs, DEFAULT_WORK_DIR, DEFAULT_CHDIR, ARCHITECTURE_TABLE
-import argparse
 import sys
 import os
 import os.path
 
 import unittest
-import traceback
 import shlex
 
 if (sys.version_info[0] >= 3):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -109,12 +109,7 @@ def dummy_getstatusoutput(x):
         "cd /alidist && git rev-parse HEAD": (0, "6cec7b7b3769826219dfa85e5daa6de6522229a0"),
         'which pigz': (1, ""),
         'tar --ignore-failed-read -cvvf /dev/null /dev/zero': (0, ""),
-        'GIT_DIR=/alidist/.git git symbolic-ref -q HEAD': (0, "master")
-    }[x]
-
-
-def dummy_getStatusOutputBash(x):
-    return {
+        'GIT_DIR=/alidist/.git git symbolic-ref -q HEAD': (0, "master"),
         'git ls-remote --heads --tags /sw/MIRROR/root': (0, TEST_ROOT_GIT_REFS),
         'git ls-remote --heads --tags /sw/MIRROR/zlib': (0, TEST_ZLIB_GIT_REFS)
     }[x]
@@ -214,7 +209,6 @@ class BuildTestCase(unittest.TestCase):
     @patch("alibuild_helpers.build.readlink", new=dummy_readlink)
     @patch("alibuild_helpers.build.banner", new=MagicMock(return_value=None))
     @patch("alibuild_helpers.build.debug")
-    @patch("alibuild_helpers.build.getStatusOutputBash", new=dummy_getStatusOutputBash)
     @patch("alibuild_helpers.workarea.is_writeable", new=MagicMock(return_value=True))
     @patch("alibuild_helpers.build.basename", new=MagicMock(return_value="aliBuild"))
     def test_coverDoBuild(self, mock_debug, mock_glob, mock_sys, mock_sync_execute, mock_workarea_execute, mock_execute):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -198,6 +198,7 @@ class BuildTestCase(unittest.TestCase):
     @patch("alibuild_helpers.workarea.path.exists", new=dummy_exists)
     @patch("alibuild_helpers.build.sys")
     @patch("alibuild_helpers.build.dieOnError", new=MagicMock())
+    @patch("alibuild_helpers.utilities.dieOnError", new=MagicMock())
     @patch("alibuild_helpers.build.readDefaults",
            new=MagicMock(return_value=(OrderedDict({"package": "defaults-release", "disable": []}), "")))
     @patch("alibuild_helpers.build.makedirs", new=MagicMock(return_value=None))

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -5,20 +5,27 @@ try:
 except ImportError:
     import mock  # Python 2
 
-from alibuild_helpers.cmd import execute
+from alibuild_helpers.cmd import execute, dockerStatusOutput
 
 import unittest
 
 class CmdTestCase(unittest.TestCase):
     @mock.patch("alibuild_helpers.cmd.debug")
     def test_execute(self, mock_debug):
-      err = execute("echo foo", mock_debug)
-      self.assertEqual(err, 0)
-      self.assertEqual(mock_debug.mock_calls, [mock.call("%s", "foo")])
-      mock_debug.reset_mock()
-      err = execute("echoo 2> /dev/null", mock_debug)
-      self.assertEqual(err, 127)
-      self.assertEqual(mock_debug.mock_calls, [])
+        err = execute("echo foo", mock_debug)
+        self.assertEqual(err, 0)
+        self.assertEqual(mock_debug.mock_calls, [mock.call("%s", "foo")])
+        mock_debug.reset_mock()
+        err = execute("echoo 2> /dev/null", mock_debug)
+        self.assertEqual(err, 127)
+        self.assertEqual(mock_debug.mock_calls, [])
+
+    @mock.patch("alibuild_helpers.cmd.getstatusoutput")
+    def test_dockerStatusOutput(self, mock_getstatusoutput):
+        dockerStatusOutput(cmd="echo foo", dockerImage="image", executor=mock_getstatusoutput)
+        self.assertEqual(mock_getstatusoutput.mock_calls,
+                         [mock.call("docker run --rm --entrypoint= image bash -c 'echo foo'")])
+
 
 if __name__ == '__main__':
-  unittest.main()
+    unittest.main()

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -4,17 +4,15 @@ import unittest
 
 # Assuming you are using the mock library to ... mock things
 try:
-    from unittest.mock import patch, call  # In Python 3, mock is built-in
+    from unittest.mock import patch  # In Python 3, mock is built-in
 except ImportError:
-    from mock import patch, call  # Python 2
+    from mock import patch  # Python 2
 
 from alibuild_helpers.utilities import doDetectArch, filterByArchitecture
 from alibuild_helpers.utilities import Hasher
 from alibuild_helpers.utilities import format
 from alibuild_helpers.utilities import asList
-from alibuild_helpers.utilities import dockerStatusOutput
 from alibuild_helpers.utilities import prunePaths
-from alibuild_helpers.utilities import to_unicode
 from alibuild_helpers.utilities import resolve_version
 import os
 
@@ -165,6 +163,14 @@ class TestUtilities(unittest.TestCase):
     self.assertEqual(format(b"%(foo)s", foo="foo"), "foo")
     self.assertRaises(KeyError, format, "%(foo)s", bar="foo")
 
+    t1 = "ताड़िद्दा"
+    t2 = u"\u0924\u093e\u0921\u093c\u093f\u0926\u094d\u0926\u093e"
+    self.assertTrue(format(t1) == t2)
+    self.assertTrue(format(t1) == format(t2))
+    self.assertTrue(format([1,2,3]) == u"[1, 2, 3]")
+    self.assertTrue(format({"a":-1}) == u"{'a': -1}")
+    self.assertTrue(format(123456) == u"123456")
+
   def test_asList(self):
     self.assertEqual(asList("a"), ["a"])
     self.assertEqual(asList(["a"]), ["a"])
@@ -177,12 +183,6 @@ class TestUtilities(unittest.TestCase):
     self.assertEqual(["AliRoot", "GCC"], list(filterByArchitecture("osx_x86-64", ["AliRoot:(?!slc6)", "GCC"])))
     self.assertEqual(["GCC"], list(filterByArchitecture("osx_x86-64", ["AliRoot:slc6", "GCC:osx"])))
     self.assertEqual([], list(filterByArchitecture("osx_x86-64", [])))
-
-  @patch("alibuild_helpers.utilities.getstatusoutput")
-  def test_dockerStatusOutput(self, mock_getstatusoutput):
-    cmd = dockerStatusOutput(cmd="echo foo", dockerImage="image", executor=mock_getstatusoutput)
-    self.assertEqual(mock_getstatusoutput.mock_calls,
-                     [call(u'docker run --rm --entrypoint= image bash -c \'echo foo\'')])
 
   def test_prunePaths(self):
     fake_env = {
@@ -214,15 +214,6 @@ class TestUtilities(unittest.TestCase):
       self.assertTrue(fake_env_copy["LD_LIBRARY_PATH"] == "/sw/lib")
       self.assertTrue(fake_env_copy["DYLD_LIBRARY_PATH"] == "/sw/lib")
       self.assertTrue(fake_env_copy["ALIBUILD_VERSION"] == "v1.0.0")
-
-  def test_to_unicode(self):
-    t1 = "ताड़िद्दा"
-    t2 = u"\u0924\u093e\u0921\u093c\u093f\u0926\u094d\u0926\u093e"
-    self.assertTrue(to_unicode(t1) == t2)
-    self.assertTrue(to_unicode(t1) == to_unicode(t2))
-    self.assertTrue(to_unicode([1,2,3]) == u"[1, 2, 3]")
-    self.assertTrue(to_unicode({"a":-1}) == u"{'a': -1}")
-    self.assertTrue(to_unicode(123456) == u"123456")
 
   def test_resolver(self):
     spec = {"package": "test-pkg",

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -31,11 +31,6 @@ def reference_basedir_exists(x):
     "sw/MIRROR": False
   }[x]
 
-def allow_directory_creation(x):
-  if x.startswith("mkdir"):
-    return (0, "")
-  return (1, "")
-
 def allow_git_clone(x, mock_git_clone, mock_git_fetch, **k):
   s = " ".join(x) if isinstance(x, list) else x
   if re.search("^git clone ", s):
@@ -46,19 +41,17 @@ def allow_git_clone(x, mock_git_clone, mock_git_fetch, **k):
 
 class WorkareaTestCase(unittest.TestCase):
 
-    @mock.patch("alibuild_helpers.workarea.getstatusoutput")
     @mock.patch("alibuild_helpers.workarea.execute")
     @mock.patch("alibuild_helpers.workarea.path")
     @mock.patch("alibuild_helpers.workarea.debug")
     @mock.patch("alibuild_helpers.workarea.os")
     @mock.patch("alibuild_helpers.workarea.is_writeable")
-    def test_referenceSourceExistsNonWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute, mock_getstatusoutput):
+    def test_referenceSourceExistsNonWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute):
       # Reference sources exists but cannot be written
       # The reference repo is set nevertheless but not updated
       mock_path.exists.side_effect = lambda x: True
       mock_is_writeable.side_effect = lambda x: False
       mock_os.path.join.side_effect = join
-      mock_getstatusoutput.side_effect = allow_directory_creation
       mock_git_clone = MagicMock(return_value=None)
       mock_git_fetch = MagicMock(return_value=None)
       mock_execute.side_effect = lambda x, **k: allow_git_clone(x, mock_git_clone, mock_git_fetch, *k)
@@ -75,19 +68,17 @@ class WorkareaTestCase(unittest.TestCase):
       self.assertEqual(spec.get("reference"), reference)
       self.assertEqual(True, call('Updating references.') in mock_debug.mock_calls)
 
-    @mock.patch("alibuild_helpers.workarea.getstatusoutput")
     @mock.patch("alibuild_helpers.workarea.execute")
     @mock.patch("alibuild_helpers.workarea.path")
     @mock.patch("alibuild_helpers.workarea.debug")
     @mock.patch("alibuild_helpers.workarea.os")
     @mock.patch("alibuild_helpers.workarea.is_writeable")
-    def test_referenceSourceExistsWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute, mock_getstatusoutput):
+    def test_referenceSourceExistsWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute):
       # Reference sources exists and can be written
       # The reference repo is set nevertheless but not updated
       mock_path.exists.side_effect = lambda x: True
       mock_is_writeable.side_effect = lambda x: True
       mock_os.path.join.side_effect = join
-      mock_getstatusoutput.side_effect = allow_directory_creation
       mock_git_clone = MagicMock(return_value=None)
       mock_git_fetch = MagicMock(return_value=None)
       mock_execute.side_effect = lambda x, **k: allow_git_clone(x, mock_git_clone, mock_git_fetch, *k)
@@ -104,13 +95,12 @@ class WorkareaTestCase(unittest.TestCase):
       self.assertEqual(spec.get("reference"), reference)
       self.assertEqual(True, call('Updating references.') in mock_debug.mock_calls)
 
-    @mock.patch("alibuild_helpers.workarea.getstatusoutput")
     @mock.patch("alibuild_helpers.workarea.execute")
     @mock.patch("alibuild_helpers.workarea.path")
     @mock.patch("alibuild_helpers.workarea.debug")
     @mock.patch("alibuild_helpers.workarea.os")
     @mock.patch("alibuild_helpers.workarea.is_writeable")
-    def test_referenceBasedirExistsWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute, mock_getstatusoutput):
+    def test_referenceBasedirExistsWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute):
       """
       The referenceSources directory exists and it's writeable
       Reference sources are already there
@@ -118,7 +108,6 @@ class WorkareaTestCase(unittest.TestCase):
       mock_path.exists.side_effect = lambda x: True
       mock_is_writeable.side_effect = lambda x: True
       mock_os.path.join.side_effect = join
-      mock_getstatusoutput.side_effect = allow_directory_creation
       mock_git_clone = MagicMock(return_value=None)
       mock_git_fetch = MagicMock(return_value=None)
       mock_execute.side_effect = lambda x, **k: allow_git_clone(x, mock_git_clone, mock_git_fetch, *k)
@@ -132,13 +121,12 @@ class WorkareaTestCase(unittest.TestCase):
       mock_os.makedirs.assert_called_with('%s/sw/MIRROR' % getcwd())
       self.assertEqual(mock_git_fetch.call_count, 1, "Expected one call to git fetch (called %d times instead)" % mock_git_fetch.call_count)
 
-    @mock.patch("alibuild_helpers.workarea.getstatusoutput")
     @mock.patch("alibuild_helpers.workarea.execute")
     @mock.patch("alibuild_helpers.workarea.path")
     @mock.patch("alibuild_helpers.workarea.debug")
     @mock.patch("alibuild_helpers.workarea.os")
     @mock.patch("alibuild_helpers.workarea.is_writeable")
-    def test_referenceBasedirNotExistsWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute, mock_getstatusoutput):
+    def test_referenceBasedirNotExistsWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute):
       """
       The referenceSources directory exists and it's writeable
       Reference sources are not already there
@@ -147,7 +135,6 @@ class WorkareaTestCase(unittest.TestCase):
       mock_is_writeable.side_effect = lambda x: False # not writeable
       mock_os.path.join.side_effect = join
       mock_os.makedirs.side_effect = lambda x: True
-      mock_getstatusoutput.side_effect = allow_directory_creation
       mock_git_clone = MagicMock(return_value=None)
       mock_git_fetch = MagicMock(return_value=None)
       mock_execute.side_effect = lambda x, **k: allow_git_clone(x, mock_git_clone, mock_git_fetch, *k)
@@ -162,13 +149,12 @@ class WorkareaTestCase(unittest.TestCase):
       mock_os.makedirs.assert_called_with('%s/sw/MIRROR' % getcwd())
       self.assertEqual(mock_git_clone.call_count, 0, "Expected no calls to git clone (called %d times instead)" % mock_git_clone.call_count)
 
-    @mock.patch("alibuild_helpers.workarea.getstatusoutput")
     @mock.patch("alibuild_helpers.workarea.execute")
     @mock.patch("alibuild_helpers.workarea.path")
     @mock.patch("alibuild_helpers.workarea.debug")
     @mock.patch("alibuild_helpers.workarea.os")
     @mock.patch("alibuild_helpers.workarea.is_writeable")
-    def test_referenceSourceNotExistsWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute, mock_getstatusoutput):
+    def test_referenceSourceNotExistsWriteable(self, mock_is_writeable, mock_os, mock_debug, mock_path, mock_execute):
       """
       The referenceSources directory does not exist and it's writeable
       Reference sources are not already there
@@ -177,7 +163,6 @@ class WorkareaTestCase(unittest.TestCase):
       mock_is_writeable.side_effect = lambda x: True  # is writeable
       mock_os.path.join.side_effect = join
       mock_os.makedirs.side_effect = lambda x: True
-      mock_getstatusoutput.side_effect = allow_directory_creation
       mock_git_clone = MagicMock(return_value=None)
       mock_git_fetch = MagicMock(return_value=None)
       mock_execute.side_effect = lambda x, **k: allow_git_clone(x, mock_git_clone, mock_git_fetch, *k)


### PR DESCRIPTION
Setting up and cleaning up a Docker container for each check takes annoyingly long, so just spawn a single container and run commands inside it individually.

Tested using `aliDoctor O2 --defaults o2 --docker` on slc7 with python2 and python3.