### PR TITLE
Change confusing warning message when no tarball is found

### DIFF
--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -151,8 +151,7 @@ class HttpRemoteSync:
         break
 
     if store_path is None or use_tarball is None:
-      warning("%s (%s) not fetched: have you tried updating the recipes?",
-              p, ", ".join(spec["remote_hashes"]))
+      debug("Nothing fetched for %s (%s)", p, ", ".join(spec["remote_hashes"]))
       return
 
     links_path = resolve_links_path(self.architecture, spec["package"])


### PR DESCRIPTION
This should be a debug message instead, as it isn't a problem users need to be informed about a lot of the time.