### PR TITLE
Rebuild later packages if dev package changes

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -170,8 +170,9 @@ def storeHashes(package, specs, isDevelPkg, considerRelocation):
   dh = Hasher()
   for dep in spec.get("requires", []):
     # At this point, our dependencies have a single hash, local or remote.
-    h_all(specs[dep]["hash"])
-    dh(specs[dep]["hash"] + specs[dep].get("devel_hash", ""))
+    hash_and_devel_hash = specs[dep]["hash"] + specs[dep].get("devel_hash", "")
+    h_all(hash_and_devel_hash)
+    dh(hash_and_devel_hash)
 
   if isDevelPkg and "incremental_recipe" in spec:
     h_all(spec["incremental_recipe"])


### PR DESCRIPTION
If a development package has committed or uncommitted changes, any packages depending on it should be rebuilt with the new code. This patch implements this.

This is done by incorporating the `devel_hash` of every dependency (if present) in a package's overall hash, so that if a dependency changes, we rebuild packages that depend on it. A dev package's hash itself doesn't change, however, so we keep rebuilding it in the same build area.