### PR TITLE
Use a connection pool for HTTP remote stores

### DIFF
--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -37,13 +37,13 @@ class HttpRemoteSync:
     self.writeStore = ""
     self.architecture = architecture
     self.workdir = workdir
+    self.insecure = insecure
     self.httpTimeoutSec = 15
     self.httpConnRetries = 4
     self.httpBackoff = 0.4
-    self._session = requests.Session()
-    self._session.verify = not insecure
 
-  def getRetry(self, url, dest=None, returnResult=False, log=True):
+  def getRetry(self, url, dest=None, returnResult=False, log=True, session=None):
+    get = session.get if session is not None else requests.get
     for i in range(0, self.httpConnRetries):
       if i > 0:
         pauseSec = self.httpBackoff * (2 ** (i - 1))
@@ -61,7 +61,7 @@ class HttpRemoteSync:
         if dest or returnResult:
           # Destination specified -- file (dest) or buffer (returnResult).
           # Use requests in stream mode
-          resp = self._session.get(url, stream=True, timeout=self.httpTimeoutSec)
+          resp = get(url, stream=True, verify=not self.insecure, timeout=self.httpTimeoutSec)
           size = int(resp.headers.get("content-length", "-1"))
           downloaded = 0
           reportTime = time.time()
@@ -97,7 +97,7 @@ class HttpRemoteSync:
           if s3Request:
             [bucket, prefix] = s3Request.groups()
             url = "https://s3.cern.ch/swift/v1/%s/?prefix=%s" % (bucket, prefix.lstrip("/"))
-            resp = self._session.get(url, timeout=self.httpTimeoutSec)
+            resp = get(url, verify=not self.insecure, timeout=self.httpTimeoutSec)
             if resp.status_code == 404:
               # No need to retry any further
               return None
@@ -106,7 +106,7 @@ class HttpRemoteSync:
                     for x in resp.text.split()]
           else:
             # No destination specified: JSON request
-            resp = self._session.get(url, timeout=self.httpTimeoutSec)
+            resp = get(url, verify=not self.insecure, timeout=self.httpTimeoutSec)
             if resp.status_code == 404:
               # No need to retry any further
               return None
@@ -140,63 +140,67 @@ class HttpRemoteSync:
                 p, pkg_hash)
           return
 
-    debug("Updating remote store for package %s; trying hashes %s",
-          p, ", ".join(spec["remote_hashes"]))
-    store_path = use_tarball = None
-    # Find the first tarball that matches any possible hash and fetch it.
-    for pkg_hash in spec["remote_hashes"]:
-      store_path = resolve_store_path(self.architecture, pkg_hash)
-      tarballs = self.getRetry("%s/%s/" % (self.remoteStore, store_path))
-      if tarballs:
-        use_tarball = tarballs[0]["name"]
-        break
+    with requests.Session() as session:
+      debug("Updating remote store for package %s; trying hashes %s",
+            p, ", ".join(spec["remote_hashes"]))
+      store_path = use_tarball = None
+      # Find the first tarball that matches any possible hash and fetch it.
+      for pkg_hash in spec["remote_hashes"]:
+        store_path = resolve_store_path(self.architecture, pkg_hash)
+        tarballs = self.getRetry("%s/%s/" % (self.remoteStore, store_path),
+                                 session=session)
+        if tarballs:
+          use_tarball = tarballs[0]["name"]
+          break
 
-    if store_path is None or use_tarball is None:
-      debug("Nothing fetched for %s (%s)", p, ", ".join(spec["remote_hashes"]))
-      return
+      if store_path is None or use_tarball is None:
+        debug("Nothing fetched for %s (%s)", p, ", ".join(spec["remote_hashes"]))
+        return
 
-    links_path = resolve_links_path(self.architecture, spec["package"])
-    execute("mkdir -p {}/{} {}/{}".format(self.workdir, store_path,
-                                          self.workdir, links_path))
+      links_path = resolve_links_path(self.architecture, spec["package"])
+      execute("mkdir -p {}/{} {}/{}".format(self.workdir, store_path,
+                                            self.workdir, links_path))
 
-    destPath = os.path.join(self.workdir, store_path, use_tarball)
-    if not os.path.isfile(destPath):
-      # Do not download twice
-      self.getRetry("/".join((self.remoteStore, store_path, use_tarball)),
-                    destPath)
+      destPath = os.path.join(self.workdir, store_path, use_tarball)
+      if not os.path.isfile(destPath):
+        # Do not download twice
+        self.getRetry("/".join((self.remoteStore, store_path, use_tarball)),
+                      destPath, session=session)
 
-    # Fetch manifest file with initial symlinks. This file is updated
-    # regularly; we use it to avoid many small network requests.
-    manifest = self.getRetry("%s/%s.manifest" % (self.remoteStore, links_path),
-                             returnResult=True)
-    symlinks = {
-      linkname.decode("utf-8"): target.decode("utf-8")
-      for linkname, sep, target in (line.partition(b"\t")
-                                    for line in manifest.splitlines())
-      if sep and linkname and target
-    }
-    # If we've just downloaded a tarball, add a symlink to it.
-    # We need to strip the leading TARS/ first, though.
-    assert store_path.startswith("TARS/"), store_path
-    symlinks[use_tarball] = os.path.join(store_path[len("TARS/"):], use_tarball)
-    # Now add any remaining symlinks that aren't in the manifest yet. There
-    # should always be relatively few of these, as the separate network
-    # requests are a bit expensive.
-    for link in self.getRetry("%s/%s/" % (self.remoteStore, links_path)):
-      linkname = link["name"]
-      if linkname in symlinks:
-        # This symlink is already present in the manifest.
-        continue
-      if os.path.islink(os.path.join(self.workdir, links_path, linkname)):
-        # We have this symlink locally. With local revisions, we won't produce
-        # revisions that will conflict with remote revisions unless we upload
-        # them anyway, so there's no need to redownload.
-        continue
-      # This symlink isn't in the manifest yet, and we don't have it locally,
-      # so download it individually.
-      symlinks[linkname] = self.getRetry(
-        "/".join((self.remoteStore, links_path, linkname)),
-        returnResult=True, log=False).decode("utf-8").rstrip("\r\n")
+      # Fetch manifest file with initial symlinks. This file is updated
+      # regularly; we use it to avoid many small network requests.
+      manifest = self.getRetry("%s/%s.manifest" % (self.remoteStore, links_path),
+                               returnResult=True, session=session)
+      symlinks = {
+        linkname.decode("utf-8"): target.decode("utf-8")
+        for linkname, sep, target in (line.partition(b"\t")
+                                      for line in manifest.splitlines())
+        if sep and linkname and target
+      }
+      # If we've just downloaded a tarball, add a symlink to it.
+      # We need to strip the leading TARS/ first, though.
+      assert store_path.startswith("TARS/"), store_path
+      symlinks[use_tarball] = os.path.join(store_path[len("TARS/"):], use_tarball)
+      # Now add any remaining symlinks that aren't in the manifest yet. There
+      # should always be relatively few of these, as the separate network
+      # requests are a bit expensive.
+      for link in self.getRetry("%s/%s/" % (self.remoteStore, links_path),
+                                session=session):
+        linkname = link["name"]
+        if linkname in symlinks:
+          # This symlink is already present in the manifest.
+          continue
+        if os.path.islink(os.path.join(self.workdir, links_path, linkname)):
+          # We have this symlink locally. With local revisions, we won't produce
+          # revisions that will conflict with remote revisions unless we upload
+          # them anyway, so there's no need to redownload.
+          continue
+        # This symlink isn't in the manifest yet, and we don't have it locally,
+        # so download it individually.
+        symlinks[linkname] = \
+            self.getRetry("/".join((self.remoteStore, links_path, linkname)),
+                          returnResult=True, log=False, session=session) \
+                .decode("utf-8").rstrip("\r\n")
     for linkname, target in symlinks.items():
       execute("ln -nsf ../../{target} {workdir}/{linkdir}/{name}".format(
         workdir=self.workdir, linkdir=links_path, name=linkname,

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -183,7 +183,7 @@ def dummy_exists(x):
 class BuildTestCase(unittest.TestCase):
     @patch("alibuild_helpers.analytics", new=MagicMock())
     @patch("alibuild_helpers.git", new=MagicMock(partialCloneFilter="--filter=blob:none"))
-    @patch("alibuild_helpers.sync.get", new=MagicMock())
+    @patch("requests.Session.get", new=MagicMock())
     @patch("alibuild_helpers.build.execute")
     @patch("alibuild_helpers.workarea.execute")
     @patch("alibuild_helpers.sync.execute")

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -179,10 +179,13 @@ def dummy_exists(x):
     }[x]
 
 
+git_mock = MagicMock(partialCloneFilter="--filter=blob:none")
+sys.modules["alibuild_helpers.git"] = git_mock
+
+
 # A few errors we should handle, together with the expected result
 class BuildTestCase(unittest.TestCase):
     @patch("alibuild_helpers.analytics", new=MagicMock())
-    @patch("alibuild_helpers.git", new=MagicMock(partialCloneFilter="--filter=blob:none"))
     @patch("requests.Session.get", new=MagicMock())
     @patch("alibuild_helpers.build.execute")
     @patch("alibuild_helpers.workarea.execute")

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -65,7 +65,7 @@ class SyncTestCase(unittest.TestCase):
     @patch("alibuild_helpers.sync.execute", new=lambda cmd, printer=None: 0)
     @patch("alibuild_helpers.sync.debug")
     @patch("alibuild_helpers.sync.error")
-    @patch("alibuild_helpers.sync.get")
+    @patch("requests.Session.get")
     def test_http_remote(self, mock_get, mock_error, mock_debug):
         mock_get.side_effect = self.mock_get
         syncer = sync.HttpRemoteSync(remoteStore="https://localhost/test",


### PR DESCRIPTION
This way, we only connect to a HTTP remote once, and then keep reusing this connection for each request. This should give a speed-up, especially for the many small requests when listing directories.

@ktf: Is it OK to keep a single connection open for the lifetime of the process, i.e. potentially hours? Or should aliBuild instead open a new connection for syncing each package individually, in which case we'd have to open 2n connections, where n is the number of packages needed, but each connection would only last a few seconds?