### PR TITLE
Use a wrapper script that sanitises the environment for OpenSSL-sensitive executables

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -4,7 +4,7 @@ from alibuild_helpers import __version__
 from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, error, info, banner, warning
 from alibuild_helpers.log import dieOnError
-from alibuild_helpers.cmd import execute, getstatusoutput, DockerRunner, BASH
+from alibuild_helpers.cmd import execute, getstatusoutput, DockerRunner, BASH, install_wrapper_script
 from alibuild_helpers.utilities import star, prunePaths
 from alibuild_helpers.utilities import resolve_store_path
 from alibuild_helpers.utilities import format, parseDefaults, readDefaults
@@ -265,6 +265,8 @@ def doBuild(args, parser):
   debug("Number of parallel builds: %d", args.jobs)
   debug("Using %sBuild from %sbuild@%s recipes in %sdist@%s",
         star(), star(), __version__, star(), os.environ["ALIBUILD_ALIDIST_HASH"])
+
+  install_wrapper_script("git", workDir)
 
   with DockerRunner(dockerImage, ["--network=host"]) as getstatusoutput_docker:
     my_gzip = "pigz" if getstatusoutput_docker("which pigz")[0] == 0 else "gzip"

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -13,7 +13,7 @@ from alibuild_helpers.utilities import validateDefaults
 from alibuild_helpers.utilities import Hasher
 from alibuild_helpers.utilities import yamlDump
 from alibuild_helpers.utilities import resolve_tag, resolve_version
-from alibuild_helpers.git import partialCloneFilter
+from alibuild_helpers.git import git, partialCloneFilter
 from alibuild_helpers.sync import (NoRemoteSync, HttpRemoteSync, S3RemoteSync,
                                    Boto3RemoteSync, RsyncRemoteSync)
 import yaml
@@ -37,10 +37,12 @@ import shutil
 import sys
 import time
 
+
 def writeAll(fn, txt):
   f = open(fn, "w")
   f.write(txt)
   f.close()
+
 
 def readHashFile(fn):
   try:
@@ -48,16 +50,6 @@ def readHashFile(fn):
   except IOError:
     return "0"
 
-def getDirectoryHash(d):
-  # We can't use git --git-dir=%s/.git or git -C %s here as the former requires
-  # that the directory we're inspecting to be the root of a git directory, not
-  # just contained in one (and that breaks CI tests), and the latter isn't
-  # supported by the git version we have on slc6.
-  # Silence cd as shell configuration can cause the new directory to be echoed.
-  err, out = getstatusoutput("cd %s >/dev/null 2>&1 && "
-                             "git rev-parse HEAD" % quote(d))
-  dieOnError(err, "Impossible to find reference for %s" % d)
-  return out
 
 # Creates a directory in the store which contains symlinks to the package
 # and its direct / indirect dependencies
@@ -250,7 +242,7 @@ def doBuild(args, parser):
           star(), args.configDir, star())
     return 1
 
-  err, value = getstatusoutput("GIT_DIR=%s/.git git symbolic-ref -q HEAD" % args.configDir)
+  _, value = git(("symbolic-ref", "-q", "HEAD"), directory=args.configDir, check=False)
   branch_basename = re.sub("refs/heads/", "", value)
   branch_stream = re.sub("-patches$", "", branch_basename)
   # In case the basename and the stream are the same,
@@ -267,7 +259,7 @@ def doBuild(args, parser):
   if not exists(specDir):
     makedirs(specDir)
 
-  os.environ["ALIBUILD_ALIDIST_HASH"] = getDirectoryHash(args.configDir)
+  os.environ["ALIBUILD_ALIDIST_HASH"] = git(("rev-parse", "HEAD"), directory=args.configDir)
 
   debug("Building for architecture %s", args.architecture)
   debug("Number of parallel builds: %d", args.jobs)
@@ -381,15 +373,12 @@ def doBuild(args, parser):
       updateReferenceRepoSpec(args.referenceSources, p, specs[p], args.fetchRepos, not args.docker)
 
       # Retrieve git heads
-      cmd = ("git", "ls-remote", "--heads", "--tags",
+      cmd = ("ls-remote", "--heads", "--tags",
              specs[p].get("reference", specs[p]["source"]))
       if specs[p]["package"] in develPkgs:
          specs[p]["source"] = join(os.getcwd(), specs[p]["package"])
-         cmd = "git", "ls-remote", "--heads", "--tags", specs[p]["source"]
-      debug("Executing %s", " ".join(cmd))
-      err, output = getstatusoutput(cmd)
-      if err:
-        raise RuntimeError("Error on %r: %s" % (" ".join(cmd), output))
+         cmd = "ls-remote", "--heads", "--tags", specs[p]["source"]
+      output = git(cmd)
       specs[p]["git_refs"] = {git_ref: git_hash for git_hash, sep, git_ref in
                               (line.partition("\t") for line in output.splitlines())
                               if sep}
@@ -427,9 +416,7 @@ def doBuild(args, parser):
       # different or if there are extra changes on top.
       if spec["package"] in develPkgs:
         # Devel package: we get the commit hash from the checked source, not from remote.
-        cmd = "cd %s && git rev-parse HEAD" % spec["source"]
-        err, out = getstatusoutput(cmd)
-        dieOnError(err, "Unable to detect current commit hash.")
+        out = git(("rev-parse", "HEAD"), directory=spec["source"])
         spec["commit_hash"] = out.strip()
         cmd = "cd %s && git diff -r HEAD && git status --porcelain" % spec["source"]
         h = Hasher()
@@ -437,15 +424,9 @@ def doBuild(args, parser):
         debug("Command %s returned %d", cmd, err)
         dieOnError(err, "Unable to detect source code changes.")
         spec["devel_hash"] = spec["commit_hash"] + h.hexdigest()
-        cmd = "cd %s && git rev-parse --abbrev-ref HEAD" % spec["source"]
-        err, out = getstatusoutput(cmd)
+        out = git(("rev-parse", "--abbrev-ref", "HEAD"), directory=spec["source"])
         if out == "HEAD":
-          err, out = getstatusoutput("cd %s && git rev-parse HEAD" % spec["source"])
-          out = out[0:10]
-        if err:
-          error("Error, unable to lookup changes in development package %s. Is it a git clone?",
-                spec["source"])
-          return 1
+          out = git(("rev-parse", "HEAD"), directory=spec["source"])[:10]
         develPackageBranch = out.replace("/", "-")
         spec["tag"] = args.develPrefix if "develPrefix" in args else develPackageBranch
         spec["commit_hash"] = "0"

--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -12,27 +12,12 @@ set +h
 function hash() { true; }
 export WORK_DIR="${WORK_DIR_OVERRIDE:-%(workDir)s}"
 
-# Insert our own git and curl wrapper scripts into $PATH, patched to use the
-# system OpenSSL, instead of the one we build ourselves.
-tmpdir=$(mktemp -d)
-export PATH="$tmpdir:$PATH"
-trap -- 'rm -rf "$tmpdir"' EXIT  # clean up on exit
-for executable in git curl; do
-  system_executable=$(command -v "$executable")
-  # Create a wrapper script that cleans up the environment, so we don't see the
-  # OpenSSL built by aliBuild.
-  cat << EOF > "$tmpdir/$executable"
-#!/bin/sh
-exec env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH $system_executable "\$@"
-EOF
-  chmod +x "$tmpdir/$executable"
-  if [ "$(command -v "$executable")" != "$tmpdir/$executable" ]; then
-    echo "WARNING: failed to install $executable wrapper script" >&2
-  fi
-done
-
 # From our dependencies
 %(dependencies)s
+
+# Insert our own wrapper scripts into $PATH, patched to use the system OpenSSL,
+# instead of the one we build ourselves.
+export PATH=$WORK_DIR/wrapper-scripts:$PATH
 
 # The following environment variables are setup by
 # the aliBuild script itself

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -1,5 +1,8 @@
+import os
+import os.path
 import sys
 from subprocess import Popen, PIPE, STDOUT
+from textwrap import dedent
 try:
   from shlex import quote  # Python 3.3+
 except ImportError:
@@ -94,3 +97,25 @@ class DockerRunner:
       getstatusoutput("docker container kill " + quote(self._container))
     self._container = None
     return False   # propagate any exception that may have occurred
+
+
+def install_wrapper_script(name, work_dir):
+  script_dir = os.path.join(work_dir, "wrapper-scripts")
+  try:
+    os.makedirs(script_dir)
+  except OSError as exc:
+    # Errno 17 means the directory already exists.
+    if exc.errno != 17:
+      raise
+  # Create a wrapper script that cleans up the environment, so we don't see the
+  # OpenSSL built by aliBuild.
+  with open(os.path.join(script_dir, name), "w") as scriptf:
+    # Compute the "real" executable path each time, as the wrapper script might
+    # be called on the host or in a container.
+    scriptf.write(dedent("""\
+    #!/bin/sh
+    exec env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH \\
+         "$(which -a "$(basename "$0")" | grep -Fxv "$0" | head -1)" "$@"
+    """))
+    os.chmod(scriptf.fileno(), 0o755)  # make the wrapper script executable
+  os.environ["PATH"] = script_dir + ":" + os.environ["PATH"]

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -117,5 +117,5 @@ def install_wrapper_script(name, work_dir):
     exec env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH \\
          "$(which -a "$(basename "$0")" | grep -Fxv "$0" | head -1)" "$@"
     """))
-    os.chmod(scriptf.fileno(), 0o755)  # make the wrapper script executable
+    os.fchmod(scriptf.fileno(), 0o755)  # make the wrapper script executable
   os.environ["PATH"] = script_dir + ":" + os.environ["PATH"]

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -24,7 +24,7 @@ def git(args, directory=".", check=True):
   err, output = getstatusoutput("""\
   set -e +x
   cd {directory} >/dev/null 2>&1
-  exec env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH git {args}
+  exec git {args}
   """.format(directory=quote(directory),
              args=" ".join(map(quote, args))))
   if check and err != 0:

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -1,4 +1,6 @@
+import shlex
 from alibuild_helpers.cmd import getstatusoutput
+from alibuild_helpers.log import debug
 
 
 def __partialCloneFilter():
@@ -7,3 +9,21 @@ def __partialCloneFilter():
 
 
 partialCloneFilter = __partialCloneFilter()
+
+
+def git(args, directory=".", check=True):
+  debug("Executing git %s (in directory %s)", " ".join(args), directory)
+  # We can't use git --git-dir=%s/.git or git -C %s here as the former requires
+  # that the directory we're inspecting to be the root of a git directory, not
+  # just contained in one (and that breaks CI tests), and the latter isn't
+  # supported by the git version we have on slc6.
+  # Silence cd as shell configuration can cause the new directory to be echoed.
+  err, output = getstatusoutput("""\
+  set -e +x
+  cd {directory} >/dev/null 2>&1
+  exec env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH git {args}
+  """.format(directory=shlex.quote(directory),
+             args=" ".join(map(shlex.quote, args))))
+  if check and err != 0:
+    raise RuntimeError("Error {} from git {}: {}".format(err, " ".join(args), output))
+  return output if check else (err, output)

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -1,4 +1,7 @@
-import shlex
+try:
+  from shlex import quote  # Python 3.3+
+except ImportError:
+  from pipes import quote  # Python 2.7
 from alibuild_helpers.cmd import getstatusoutput
 from alibuild_helpers.log import debug
 
@@ -22,8 +25,8 @@ def git(args, directory=".", check=True):
   set -e +x
   cd {directory} >/dev/null 2>&1
   exec env -u LD_LIBRARY_PATH -u DYLD_LIBRARY_PATH git {args}
-  """.format(directory=shlex.quote(directory),
-             args=" ".join(map(shlex.quote, args))))
+  """.format(directory=quote(directory),
+             args=" ".join(map(quote, args))))
   if check and err != 0:
     raise RuntimeError("Error {} from git {}: {}".format(err, " ".join(args), output))
   return output if check else (err, output)

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -13,7 +13,8 @@ try:
 except ImportError:
   from ordereddict import OrderedDict
 
-from alibuild_helpers.cmd import getoutput, getstatusoutput
+from alibuild_helpers.cmd import getoutput
+from alibuild_helpers.git import git
 from alibuild_helpers.log import dieOnError
 
 
@@ -279,9 +280,9 @@ class GitReader(object):
     self.url, self.configDir = url, configDir
   def __call__(self):
     m = re.search(r'^dist:(.*)@([^@]+)$', self.url)
-    fn,gh = m.groups()
-    err,d = getstatusoutput(format("GIT_DIR=%(dist)s/.git git show %(gh)s:%(fn)s.sh",
-                                   dist=self.configDir, gh=gh, fn=fn.lower()))
+    fn, gh = m.groups()
+    err, d = git(("show", "{gh}:{fn}.sh".format(gh=gh, fn=fn.lower())),
+                 directory=self.configDir)
     if err:
       raise RuntimeError(format("Cannot read recipe %(fn)s from reference %(gh)s.\n" +
                                 "Make sure you run first (this will not alter your recipes):\n" +

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -1,16 +1,15 @@
-from alibuild_helpers.log import dieOnError, debug
-from alibuild_helpers.cmd import execute
-from alibuild_helpers.git import partialCloneFilter
-from os.path import dirname, abspath
-from alibuild_helpers.utilities import format
-
+import codecs
 import os
-import os.path as path
+import os.path
 import tempfile
 try:
   from collections import OrderedDict
 except ImportError:
   from ordereddict import OrderedDict
+
+from alibuild_helpers.log import dieOnError, debug
+from alibuild_helpers.git import git, partialCloneFilter
+
 
 def updateReferenceRepoSpec(referenceSources, p, spec, fetch, usePartialClone=True):
   """
@@ -43,46 +42,43 @@ def updateReferenceRepo(referenceSources, p, spec, fetch=True, usePartialClone=T
   @spec             : the spec of the package to be updated (an OrderedDict)
   @fetch            : whether to fetch updates: if False, only clone if not found
   """
-  assert(type(spec) == OrderedDict)
-  if not "source" in spec:
+  assert isinstance(spec, OrderedDict)
+  if "source" not in spec:
     return
 
   debug("Updating references.")
-  referenceRepo = os.path.join(abspath(referenceSources), p.lower())
+  referenceRepo = os.path.join(os.path.abspath(referenceSources), p.lower())
 
   try:
-    os.makedirs(abspath(referenceSources))
+    os.makedirs(os.path.abspath(referenceSources))
   except:
     pass
 
   if not is_writeable(referenceSources):
-    if path.exists(referenceRepo):
+    if os.path.exists(referenceRepo):
       debug("Using %s as reference for %s", referenceRepo, p)
       return referenceRepo  # reference is read-only
     else:
       debug("Cannot create reference for %s in %s", p, referenceSources)
       return None  # no reference can be found and created (not fatal)
 
-  err = False
-  logPath = os.path.join(dirname(referenceRepo), "fetch-log.txt")
-  if not path.exists(referenceRepo):
-    cmd = ["git", "clone"] + (usePartialClone and [partialCloneFilter] or []) + ["--bare", spec["source"], referenceRepo]
-    cmd = [x for x in cmd if x]
-    debug("Cloning reference repository: %s", " ".join(cmd))
-    err = execute(cmd)
+  if not os.path.exists(referenceRepo):
+    cmd = ["clone", "--bare", spec["source"], referenceRepo]
+    if usePartialClone:
+      cmd.append(partialCloneFilter)
+    git(cmd)
   elif fetch:
-    cmd = format("cd %(referenceRepo)s && "
-                 "git fetch -f --tags %(source)s >%(logPath)s 2>&1 && "
-                 "git fetch -f %(source)s '+refs/heads/*:refs/heads/*' >>%(logPath)s 2>&1",
-                 referenceRepo=referenceRepo,
-                 source=spec["source"],
-                 logPath=logPath)
-    debug("Updating reference repository: %s", cmd)
-    err = execute(cmd)
-  if os.path.exists(logPath):
-    execute("cat " + logPath)
-  dieOnError(err, "Error while updating reference repos %s." % spec["source"])
+    with codecs.open(os.path.join(os.path.dirname(referenceRepo),
+                                  "fetch-log.txt"),
+                     "w", encoding="utf-8", errors="replace") as logf:
+      err, output = git(("fetch", "-f", "--tags", spec["source"],
+                         "+refs/heads/*:refs/heads/*"),
+                        directory=referenceRepo, check=False)
+      logf.write(output)
+      debug(output)
+      dieOnError(err, "Error while updating reference repo for %s." % spec["source"])
   return referenceRepo  # reference is read-write
+
 
 def is_writeable(dirpath):
   try:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -223,6 +223,7 @@ class BuildTestCase(unittest.TestCase):
     @patch("alibuild_helpers.build.debug")
     @patch("alibuild_helpers.workarea.is_writeable", new=MagicMock(return_value=True))
     @patch("alibuild_helpers.build.basename", new=MagicMock(return_value="aliBuild"))
+    @patch("alibuild_helpers.build.install_wrapper_script", new=MagicMock())
     def test_coverDoBuild(self, mock_debug, mock_glob, mock_sys, mock_workarea_git):
         mock_workarea_git.side_effect = dummy_git
         mock_debug.side_effect = lambda *args: None


### PR DESCRIPTION
On CentOS 8, when we build our own OpenSSL from alidist, then subsequent git and curl calls fail, as they were compiled against the system OpenSSL, which has some special patches applied.

Therefore, install some wrapper scripts during the build that remove `LD_LIBRARY_PATH` and `DYLD_LIBRARY_PATH` from the environment temporarily for those programs.

When we call git from aliBuild itself (rather than from build scripts), also sanitise the environment. For this, I centralised (almost all) git calls to a single function.

This wrapping of calls needs to be done in two places, as we might be building inside a container, but we always run aliBuild's git commands on the host.