### PR TITLE
Fix errors on slc6

### DIFF
--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -64,7 +64,7 @@ def updateReferenceRepo(referenceSources, p, spec, fetch=True, usePartialClone=T
 
   if not os.path.exists(referenceRepo):
     cmd = ["clone", "--bare", spec["source"], referenceRepo]
-    if usePartialClone:
+    if usePartialClone and partialCloneFilter:
       cmd.append(partialCloneFilter)
     git(cmd)
   elif fetch:


### PR DESCRIPTION
Don't append an empty argument if we can't use `--filter=blob:none`.