### PR TITLE
Add a templating plugin

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -105,7 +105,7 @@ if __name__ == "__main__":
 
   if not decideAnalytics(exists(expanduser("~/.config/alibuild/disable-analytics")),
                          exists(expanduser("~/.config/alibuild/analytics-uuid")),
-                         sys.stdout.isatty(),
+                         sys.stdin.isatty(),
                          askForAnalytics):
     os.environ["ALIBUILD_NO_ANALYTICS"] = "1"
   else:

--- a/alibuild_helpers/templating_plugin.py
+++ b/alibuild_helpers/templating_plugin.py
@@ -1,0 +1,18 @@
+"""A text templating plugin for aliBuild.
+
+This plugin allows reusing specs like those that would be used during the
+build, for instance to get the "real" version numbers for various packages.
+
+We use Jinja2 as the templating language, read the user-provided template from
+stdin and print the rendered output to stdout.
+"""
+
+import sys
+from jinja2.sandbox import SandboxedEnvironment
+
+
+def build_plugin(specs, args, build_order):
+    """Read a user-provided template from stdin and render it."""
+    print(SandboxedEnvironment(autoescape=False)
+          .from_string(sys.stdin.read())
+          .render(specs=specs, args=args, build_order=build_order))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 requests
 pyyaml
 distro
+jinja2
 boto3; python_version >= '3.6'
 futures; python_version == '2.7'
 futures; python_version == '2.6'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-install_requires = ['pyyaml', 'requests', 'distro']
+install_requires = ['pyyaml', 'requests', 'distro', 'jinja2']
 # Old setuptools versions (which pip2 uses) don't support range comparisons
 # (like :python_version >= "3.6") in extras_require, so do this ourselves here.
 if sys.version_info >= (3, 6):


### PR DESCRIPTION
This allows access to the program state just before the build would start, exposed to a user-provided Jinja2 template.

Required for https://github.com/alisw/ali-bot/pull/1153.