### PR TITLE
Override Docker image entrypoint for DockerRunner too

### DIFF
--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -92,7 +92,7 @@ class DockerRunner:
   def __enter__(self):
     if self._docker_image:
       # "sleep inf" pauses forever, until we kill it.
-      cmd = ["docker", "run", "--detach", "--rm"]
+      cmd = ["docker", "run", "--detach", "--rm", "--entrypoint="]
       cmd += self._docker_run_args
       cmd += [self._docker_image, "sleep", "inf"]
       self._container = getoutput(cmd).strip()

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -9,6 +9,7 @@ from alibuild_helpers.cmd import execute, DockerRunner
 
 import unittest
 
+
 class CmdTestCase(unittest.TestCase):
     @mock.patch("alibuild_helpers.cmd.debug")
     def test_execute(self, mock_debug):
@@ -25,7 +26,7 @@ class CmdTestCase(unittest.TestCase):
     def test_DockerRunner(self, mock_getstatusoutput, mock_getoutput):
         mock_getoutput.side_effect = lambda cmd: "container-id\n"
         with DockerRunner("image", ["extra arg"]) as getstatusoutput_docker:
-            mock_getoutput.assert_called_with(["docker", "run", "--detach", "--rm",
+            mock_getoutput.assert_called_with(["docker", "run", "--detach", "--rm", "--entrypoint=",
                                                "extra arg", "image", "sleep", "inf"])
             getstatusoutput_docker("echo foo")
             mock_getstatusoutput.assert_called_with("docker container exec container-id bash -c 'echo foo'")


### PR DESCRIPTION
Running commands in Docker images with non-empty entrypoints fails. This fixes that issue.

Cc: @adriansev