### PR TITLE
Explicitly take write permission before deleting

### DIFF
--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -72,6 +72,9 @@ fi
 rm -fr "$WORK_DIR/INSTALLROOT/$PKGHASH"
 # We remove the build directory only if we are not in incremental mode.
 if [[ "$INCREMENTAL_BUILD_HASH" == 0 ]]; then
+  # Golang installs stuff without write permissions for ourselves sometimes.
+  # This makes a plain `rm -rf` fail, so give ourselves write permission first.
+  chmod -R o+w "$BUILDROOT"
   rm -rf "$BUILDROOT"
 fi
 mkdir -p "$INSTALLROOT" "$BUILDROOT" "$BUILDDIR" "$WORK_DIR/INSTALLROOT/$PKGHASH/$PKGPATH"

--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -71,10 +71,10 @@ if [[ ${COMMIT_HASH} != ${GIT_TAG} && "${SHORT_TAG:-0}" != ${COMMIT_HASH} ]]; th
 fi
 rm -fr "$WORK_DIR/INSTALLROOT/$PKGHASH"
 # We remove the build directory only if we are not in incremental mode.
-if [[ "$INCREMENTAL_BUILD_HASH" == 0 ]]; then
+if [[ "$INCREMENTAL_BUILD_HASH" == 0 ]] && ! rm -rf "$BUILDROOT"; then
   # Golang installs stuff without write permissions for ourselves sometimes.
-  # This makes a plain `rm -rf` fail, so give ourselves write permission first.
-  chmod -R o+w "$BUILDROOT"
+  # This makes the `rm -rf` above fail, so give ourselves write permission.
+  chmod -R o+w "$BUILDROOT" || :
   rm -rf "$BUILDROOT"
 fi
 mkdir -p "$INSTALLROOT" "$BUILDROOT" "$BUILDDIR" "$WORK_DIR/INSTALLROOT/$PKGHASH/$PKGPATH"


### PR DESCRIPTION
Golang installs stuff without write permissions for the owning user sometimes. In this case, take write permissions explicitly, so we can delete the old build directory.