### PR TITLE
Normalise symlinks from HTTPS remotes

### DIFF
--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -204,7 +204,7 @@ class HttpRemoteSync:
     for linkname, target in symlinks.items():
       execute("ln -nsf ../../{target} {workdir}/{linkdir}/{name}".format(
         workdir=self.workdir, linkdir=links_path, name=linkname,
-        target=target))
+        target=target.lstrip("./")))
 
   def syncToRemote(self, p, spec):
     pass


### PR DESCRIPTION
This gets rid of "symlink couldn't be parsed" errors.