### PR TITLE
Allow users to input git credentials without prompts overwriting each other

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -106,7 +106,10 @@ def update_git_repos(args, specs, buildOrder, develPkgs):
     # Now execute git commands for private packages one-by-one, so the user can
     # type their username and password without multiple prompts interfering.
     for package in requires_auth:
-        banner("If prompted now, enter your username and password for %s below",
+        banner("If prompted now, enter your username and password for %s below\n"
+               "If you are prompted too often, see: "
+               "https://alisw.github.io/alibuild/troubleshooting.html"
+               "#alibuild-keeps-asking-for-my-password",
                specs[package]["source"])
         update_repo(package, git_prompt=True)
         debug("%r package updated: %d refs found", package,

--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -86,7 +86,7 @@ fi
 
 # Reference statements
 %(referenceStatement)s
-%(partialCloneStatement)s
+%(gitOptionsStatement)s
 
 if [ -z "$CACHED_TARBALL" ]; then
   case "$SOURCE0" in
@@ -105,7 +105,7 @@ if [ -z "$CACHED_TARBALL" ]; then
       else
         # In case there is a stale link / file, for whatever reason.
         rm -rf "$SOURCEDIR"
-        git clone -n $GIT_PARTIAL_CLONE_FILTER ${GIT_REFERENCE:+--reference "$GIT_REFERENCE"} "$SOURCE0" "$SOURCEDIR"
+        git clone -n $GIT_CLONE_SPEEDUP ${GIT_REFERENCE:+--reference "$GIT_REFERENCE"} "$SOURCE0" "$SOURCEDIR"
         cd "$SOURCEDIR"
         git remote set-url --push origin "$WRITE_REPO"
         git checkout -f "$GIT_TAG"

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -14,7 +14,7 @@ def __partialCloneFilter():
 partialCloneFilter = __partialCloneFilter()
 
 
-def git(args, directory=".", check=True):
+def git(args, directory=".", check=True, prompt=True):
   debug("Executing git %s (in directory %s)", " ".join(args), directory)
   # We can't use git --git-dir=%s/.git or git -C %s here as the former requires
   # that the directory we're inspecting to be the root of a git directory, not
@@ -24,9 +24,11 @@ def git(args, directory=".", check=True):
   err, output = getstatusoutput("""\
   set -e +x
   cd {directory} >/dev/null 2>&1
-  exec git {args}
+  {prompt_var} git {args}
   """.format(directory=quote(directory),
-             args=" ".join(map(quote, args))))
+             args=" ".join(map(quote, args)),
+             # GIT_TERMINAL_PROMPT is only supported in git 2.3+.
+             prompt_var="GIT_TERMINAL_PROMPT=0" if not prompt else ""))
   if check and err != 0:
     raise RuntimeError("Error {} from git {}: {}".format(err, " ".join(args), output))
   return output if check else (err, output)

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -6,12 +6,12 @@ from alibuild_helpers.cmd import getstatusoutput
 from alibuild_helpers.log import debug
 
 
-def __partialCloneFilter():
-  err, out = getstatusoutput("LANG=C git clone --filter=blob:none 2>&1 | grep 'unknown option'")
-  return err and "--filter=blob:none" or ""
-
-
-partialCloneFilter = __partialCloneFilter()
+def clone_speedup_options():
+  """Return a list of options supported by the system git which speed up cloning."""
+  _, out = getstatusoutput("LANG=C git clone --filter=blob:none")
+  if "unknown option" not in out and "invalid filter-spec" not in out:
+    return ["--filter=blob:none"]
+  return []
 
 
 def git(args, directory=".", check=True, prompt=True):

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -1,4 +1,3 @@
-from alibuild_helpers.cmd import execute
 from alibuild_helpers.git import git
 from alibuild_helpers.utilities import getPackageList, parseDefaults, readDefaults, validateDefaults
 from alibuild_helpers.log import debug, error, warning, banner, info
@@ -8,10 +7,6 @@ from alibuild_helpers.workarea import updateReferenceRepoSpec
 from os.path import join
 import os.path as path
 import os, sys
-try:
-  from collections import OrderedDict
-except ImportError:
-  from ordereddict import OrderedDict
 
 def parsePackagesDefinition(pkgname):
   return [ dict(zip(["name","ver"], y.split("@")[0:2]))

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -8,7 +8,7 @@ except ImportError:
   from ordereddict import OrderedDict
 
 from alibuild_helpers.log import dieOnError, debug, info
-from alibuild_helpers.git import git, partialCloneFilter
+from alibuild_helpers.git import git, clone_speedup_options
 
 
 def updateReferenceRepoSpec(referenceSources, p, spec,
@@ -68,8 +68,8 @@ def updateReferenceRepo(referenceSources, p, spec,
 
   if not os.path.exists(referenceRepo):
     cmd = ["clone", "--bare", spec["source"], referenceRepo]
-    if usePartialClone and partialCloneFilter:
-      cmd.append(partialCloneFilter)
+    if usePartialClone:
+      cmd.extend(clone_speedup_options())
     # This might take a long time, so show the user what's going on.
     info("Cloning git repository for %s...", spec["package"])
     git(cmd, prompt=allowGitPrompt)

--- a/docs/troubleshooting.markdown
+++ b/docs/troubleshooting.markdown
@@ -301,7 +301,7 @@ and then adapt you PATH to pickup the local installation, e.g. via:
     export PATH=~/.local/bin:$PATH
 
 
-### aliBuild and/or git keep asking for my username and password
+### aliBuild keeps asking for my password
 
 Some packages you may need to build have their source code in a protected repository on CERN GitLab.
 This means that you may be asked for a username and password when you run `aliBuild build`.

--- a/docs/troubleshooting.markdown
+++ b/docs/troubleshooting.markdown
@@ -299,3 +299,35 @@ This means that you need to do (only once):
 and then adapt you PATH to pickup the local installation, e.g. via:
 
     export PATH=~/.local/bin:$PATH
+
+
+### aliBuild and/or git keep asking for my username and password
+
+Some packages you may need to build have their source code in a protected repository on CERN GitLab.
+This means that you may be asked for a username and password when you run `aliBuild build`.
+See below for ways to avoid being prompted too often.
+
+#### SSH authentication
+
+You can use an SSH key to authenticate with CERN GitLab.
+This way, you will not be prompted for your GitLab password at all.
+To do this, find your public key (this usually lives in `~/.ssh/id_rsa.pub`) and copy the contents of the file into [your user settings on CERN GitLab][gitlab-ssh-key].
+If you have no SSH key, you can generate one using the `ssh-keygen` command.
+Then, configure git to use SSH to authenticate with CERN GitLab using the following command:
+
+```bash
+git config --global 'url.ssh://git@gitlab.cern.ch:7999/.insteadof' 'https://gitlab.cern.ch/'
+```
+
+[gitlab-ssh-key]: https://gitlab.cern.ch/-/profile/keys
+
+#### Caching passwords
+
+If you prefer not to use SSH keys as described above, you can alternatively configure git to remember the passwords you input for a short time (such as a few hours).
+In order to do this, run the command below (which remembers your passwords for an hour each time you type them into git).
+
+```bash
+git config --global credential.helper 'cache --timeout 3600'
+```
+
+You can adjust the timeout (3600 seconds, above) to your liking, if you would prefer git to remember your passwords for longer.

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -107,7 +107,7 @@ GIT_FETCH_ROOT_ARGS = ("fetch", "-f", "--tags", "https://github.com/root-mirror/
                        "+refs/heads/*:refs/heads/*"), "/sw/MIRROR/root", False
 
 
-def dummy_git(args, directory=".", check=True):
+def dummy_git(args, directory=".", check=True, prompt=True):
     return {
         (("symbolic-ref", "-q", "HEAD"), "/alidist", False): (0, "master"),
         (("rev-parse", "HEAD"), "/alidist", True): "6cec7b7b3769826219dfa85e5daa6de6522229a0",
@@ -275,7 +275,8 @@ class BuildTestCase(unittest.TestCase):
         exit_code = doBuild(args, mock_parser)
         self.assertEqual(exit_code, 0)
         mock_debug.assert_called_with("Everything done")
-        mock_workarea_git.assert_called_once_with(list(GIT_CLONE_ZLIB_ARGS[0]))
+        mock_workarea_git.assert_called_once_with(list(GIT_CLONE_ZLIB_ARGS[0]),
+                                                  prompt=False)
 
         # Force fetching repos
         mock_workarea_git.reset_mock()

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -187,11 +187,11 @@ def dummy_exists(x):
     }.get(x, DEFAULT)
 
 
-git_mock = MagicMock(partialCloneFilter="--filter=blob:none")
-sys.modules["alibuild_helpers.git"] = git_mock
-
-
 # A few errors we should handle, together with the expected result
+@patch("alibuild_helpers.build.clone_speedup_options",
+       new=MagicMock(return_value=["--filter=blob:none"]))
+@patch("alibuild_helpers.workarea.clone_speedup_options",
+       new=MagicMock(return_value=["--filter=blob:none"]))
 class BuildTestCase(unittest.TestCase):
     @patch("alibuild_helpers.analytics", new=MagicMock())
     @patch("requests.Session.get", new=MagicMock())

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -1,0 +1,25 @@
+import unittest
+
+from alibuild_helpers.git import git
+
+MISSING_REPO = "https://github.com/alisw/nonexistent"
+MISSING_REPO_ERROR_MSG = (
+    "Error 128 from git ls-remote -ht " + MISSING_REPO + ": fatal: could "
+    "not read Username for 'https://github.com': terminal prompts disabled"
+)
+
+
+err, out = git(("--help",), check=False)
+@unittest.skipUnless(not err and out.startswith("usage:"),
+                     "need a working git executable on the system")
+class GitWrapperTestCase(unittest.TestCase):
+    """Make sure the git() wrapper function is working."""
+
+    def test_git_missing_repo(self):
+        """Check we get the right exception when credentials are required."""
+        try:
+            git(("ls-remote", "-ht", MISSING_REPO), prompt=False)
+        except RuntimeError as exc:
+            self.assertTupleEqual(exc.args, (MISSING_REPO_ERROR_MSG,))
+        else:
+            self.fail("expected git(...) to raise a RuntimeError")

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,23 +1,16 @@
-from __future__ import print_function
 from argparse import Namespace
 import os.path as path
-import sys
 import unittest
 try:
-    from unittest import mock
-    from unittest.mock import call, MagicMock  # In Python 3, mock is built-in
+    from unittest.mock import MagicMock, call, patch  # In Python 3, mock is built-in
     from io import StringIO
 except ImportError:
-    import mock
-    from mock import call, MagicMock  # Python 2
+    from mock import MagicMock, call, patch  # Python 2
     from StringIO import StringIO
 try:
     from collections import OrderedDict
 except ImportError:
     from ordereddict import OrderedDict
-
-git_mock = MagicMock(partialCloneFilter="--filter=blob:none")
-sys.modules["alibuild_helpers.git"] = git_mock
 
 from alibuild_helpers.init import doInit, parsePackagesDefinition
 
@@ -47,9 +40,9 @@ class InitTestCase(unittest.TestCase):
                        [{'ver': '', 'name': 'AliRoot'},
                         {'ver': 'v5-08-16-01', 'name': 'AliPhysics'}])
 
-    @mock.patch("alibuild_helpers.init.info")
-    @mock.patch("alibuild_helpers.init.path")
-    @mock.patch("alibuild_helpers.init.os")
+    @patch("alibuild_helpers.init.info")
+    @patch("alibuild_helpers.init.path")
+    @patch("alibuild_helpers.init.os")
     def test_doDryRunInit(self, mock_os, mock_path,  mock_info):
       fake_dist = {"repo": "alisw/alidist", "ver": "master"}
       args = Namespace(
@@ -66,14 +59,14 @@ class InitTestCase(unittest.TestCase):
       self.assertRaises(SystemExit, doInit, args)
       self.assertEqual(mock_info.mock_calls, [call('This will initialise local checkouts for %s\n--dry-run / -n specified. Doing nothing.', 'zlib,AliRoot')])
 
-    @mock.patch("alibuild_helpers.init.banner")
-    @mock.patch("alibuild_helpers.init.info")
-    @mock.patch("alibuild_helpers.init.path")
-    @mock.patch("alibuild_helpers.init.os")
-    @mock.patch("alibuild_helpers.init.git")
-    @mock.patch("alibuild_helpers.init.updateReferenceRepoSpec")
-    @mock.patch("alibuild_helpers.utilities.open")
-    @mock.patch("alibuild_helpers.init.readDefaults")
+    @patch("alibuild_helpers.init.banner")
+    @patch("alibuild_helpers.init.info")
+    @patch("alibuild_helpers.init.path")
+    @patch("alibuild_helpers.init.os")
+    @patch("alibuild_helpers.init.git")
+    @patch("alibuild_helpers.init.updateReferenceRepoSpec")
+    @patch("alibuild_helpers.utilities.open")
+    @patch("alibuild_helpers.init.readDefaults")
     def test_doRealInit(self, mock_read_defaults, mock_open, mock_update_reference, mock_git, mock_os, mock_path,  mock_info, mock_banner):
       fake_dist = {"repo": "alisw/alidist", "ver": "master"}
       mock_open.side_effect = lambda x: {

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -1,10 +1,9 @@
-from __future__ import print_function
 from os import getcwd
 import unittest
 try:
-    from unittest.mock import patch, call, MagicMock, DEFAULT  # In Python 3, mock is built-in
+    from unittest.mock import patch, MagicMock  # In Python 3, mock is built-in
 except ImportError:
-    from mock import patch, call, MagicMock, DEFAULT  # Python 2
+    from mock import patch, MagicMock  # Python 2
 try:
     from collections import OrderedDict
 except ImportError:
@@ -21,6 +20,8 @@ MOCK_SPEC = OrderedDict((
 
 @patch("alibuild_helpers.workarea.debug", new=MagicMock())
 @patch("alibuild_helpers.workarea.info", new=MagicMock())
+@patch("alibuild_helpers.workarea.clone_speedup_options",
+       new=MagicMock(return_value=["--filter=blob:none"]))
 class WorkareaTestCase(unittest.TestCase):
 
     @patch("os.path.exists")

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -60,7 +60,7 @@ class WorkareaTestCase(unittest.TestCase):
         mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd())
         mock_git.assert_called_once_with((
             "fetch", "-f", "--tags", spec["source"], "+refs/heads/*:refs/heads/*",
-        ), directory="%s/sw/MIRROR/aliroot" % getcwd(), check=False)
+        ), directory="%s/sw/MIRROR/aliroot" % getcwd(), check=False, prompt=True)
         self.assertEqual(spec.get("reference"), "%s/sw/MIRROR/aliroot" % getcwd())
 
     @patch("os.path.exists")
@@ -93,7 +93,7 @@ class WorkareaTestCase(unittest.TestCase):
         mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd())
         mock_git.assert_called_once_with(["clone", "--bare", spec["source"],
                                           "%s/sw/MIRROR/aliroot" % getcwd(),
-                                          "--filter=blob:none"])
+                                          "--filter=blob:none"], prompt=True)
         self.assertEqual(spec.get("reference"), "%s/sw/MIRROR/aliroot" % getcwd())
 
 


### PR DESCRIPTION
If a git repository cannot be accessed in parallel, try it sequentially while allowing the user to input their credentials. This fixes the issue where multiple git processes running in parallel would all present a username and password prompt, overwriting each other.

Avoiding password prompts entirely should be out of scope for aliBuild, as that requires changing the user's git configuration. Instead, I updated the documentation to specify how to cache passwords or use SSH auth instead.

Fixes #681 