### PR TITLE
Teach aliBuild about slcX_aarch64 architectures

### DIFF
--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -330,7 +330,7 @@ def doParseArgs(star):
   args = finaliseArgs(parser.parse_args(), parser, star)
   return (args, parser)
 
-VALID_ARCHS_RE = "^slc[5-9]_(x86-64|ppc64)$|^(ubuntu|ubt|osx|fedora)[0-9]*_(x86-64|arm64)$"
+VALID_ARCHS_RE = "^slc[5-9]_(x86-64|ppc64|aarch64)$|^(ubuntu|ubt|osx|fedora)[0-9]*_(x86-64|arm64)$"
 
 def matchValidArch(architecture):
   return bool(re.match(VALID_ARCHS_RE, architecture))


### PR DESCRIPTION
These are for building stuff on ARM machines running slc7.