### PR TITLE
Always rebuild if there are untracked changes

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -270,6 +270,39 @@ def storeHashes(package, specs, isDevelPkg, considerRelocation):
     list({h.hexdigest() for _, _, h, in h_alternatives} - {spec["local_revision_hash"]})
 
 
+def hash_local_changes(directory):
+  """Produce a hash of all local changes in the given git repo.
+
+  If there are untracked files, this function will fail and produce an error
+  message, as we cannot detect changes to those files.
+  """
+  class UntrackedChangesError(Exception):
+    """Signal that we cannot detect code changes due to untracked files."""
+  h = Hasher()
+  def hash_output(msg, args):
+    lines = msg % args
+    # `git status --porcelain` indicates untracked files using "??".
+    # Lines from `git diff` never start with "??".
+    if any(line.startswith("?? ") for line in lines.split("\n")):
+      raise UntrackedChangesError()
+    h(lines)
+  cmd = "cd %s && git diff -r HEAD && git status --porcelain" % directory
+  try:
+    err = execute(cmd, hash_output)
+    debug("Command %s returned %d", cmd, err)
+    dieOnError(err, "Unable to detect source code changes.")
+  except UntrackedChangesError:
+    warning("You have untracked changes in %s, so %sBuild cannot detect "
+            "whether it needs to rebuild the package. Therefore, the package "
+            "is being rebuilt unconditionally. Please use 'git add' and/or "
+            "'git commit' to track your changes in git.", directory, star())
+    # If there are untracked changes, always rebuild (hopefully incrementally)
+    # and let CMake figure out what needs to be rebuilt. Force a rebuild by
+    # changing the hash to something basically random.
+    h(str(time.time()))
+  return h.hexdigest()
+
+
 def better_tarball(spec, old, new):
   """Return which tarball we should prefer to reuse."""
   if not old: return new
@@ -466,12 +499,7 @@ def doBuild(args, parser):
         # Devel package: we get the commit hash from the checked source, not from remote.
         out = git(("rev-parse", "HEAD"), directory=spec["source"])
         spec["commit_hash"] = out.strip()
-        cmd = "cd %s && git diff -r HEAD && git status --porcelain" % spec["source"]
-        h = Hasher()
-        err = execute(cmd, lambda s, *a: h(s % a))
-        debug("Command %s returned %d", cmd, err)
-        dieOnError(err, "Unable to detect source code changes.")
-        spec["devel_hash"] = spec["commit_hash"] + h.hexdigest()
+        spec["devel_hash"] = spec["commit_hash"] + hash_local_changes(spec["source"])
         out = git(("rev-parse", "--abbrev-ref", "HEAD"), directory=spec["source"])
         if out == "HEAD":
           out = git(("rev-parse", "HEAD"), directory=spec["source"])[:10]

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -273,8 +273,8 @@ def storeHashes(package, specs, isDevelPkg, considerRelocation):
 def hash_local_changes(directory):
   """Produce a hash of all local changes in the given git repo.
 
-  If there are untracked files, this function will fail and produce an error
-  message, as we cannot detect changes to those files.
+  If there are untracked files, this function returns a unique hash to force a
+  rebuild, and logs a warning, as we cannot detect changes to those files.
   """
   class UntrackedChangesError(Exception):
     """Signal that we cannot detect code changes due to untracked files."""


### PR DESCRIPTION
For development packages, we cannot see what's changed between runs, so always rebuild the package in that case, and rely on e.g. CMake to figure out if anything needs to be rebuilt.

No change in behaviour if there are no untracked files.