### PR TITLE
Time out when git takes too long

### DIFF
--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -1,14 +1,15 @@
 import os
 import os.path
 import sys
-from subprocess import Popen, PIPE, STDOUT
+import time
+from subprocess import Popen, PIPE, STDOUT, TimeoutExpired
 from textwrap import dedent
 try:
   from shlex import quote  # Python 3.3+
 except ImportError:
   from pipes import quote  # Python 2.7
 
-from alibuild_helpers.log import debug, dieOnError
+from alibuild_helpers.log import debug, warning, dieOnError
 
 # Keep the linter happy
 if sys.version_info[0] >= 3:
@@ -43,19 +44,39 @@ def decode_with_fallback(data):
   return data
 
 
-def getoutput(command):
+def getoutput(command, timeout=None):
   """Run command, check it succeeded, and return its stdout as a string."""
   proc = Popen(command, shell=is_string(command), stdout=PIPE, stderr=PIPE)
-  stdout, stderr = proc.communicate()
+  try:
+    stdout, stderr = proc.communicate(timeout=timeout)
+  except TimeoutExpired:
+    warning("Process %r timed out; terminated", command)
+    proc.terminate()
+    stdout, stderr = proc.communicate()
+  except TypeError:
+    # On Python 2, we don't have the timeout= parameter. However, "regular"
+    # users shouldn't be running under Python 2 any more, so just don't timeout
+    # there and let the admins handle it manually.
+    stdout, stderr = proc.communicate()
   dieOnError(proc.returncode, "Command %s failed with code %d: %s" %
              (command, proc.returncode, decode_with_fallback(stderr)))
   return decode_with_fallback(stdout)
 
 
-def getstatusoutput(command):
+def getstatusoutput(command, timeout=None):
   """Run command and return its return code and output (stdout and stderr)."""
   proc = Popen(command, shell=is_string(command), stdout=PIPE, stderr=STDOUT)
-  merged_output, _ = proc.communicate()
+  try:
+    merged_output, _ = proc.communicate(timeout=timeout)
+  except TimeoutExpired:
+    warning("Process %r timed out; terminated", command)
+    proc.terminate()
+    merged_output, _ = proc.communicate()
+  except TypeError:
+    # On Python 2, we don't have the timeout= parameter. However, "regular"
+    # users shouldn't be running under Python 2 any more, so just don't timeout
+    # there and let the admins handle it manually.
+    merged_output, _ = proc.communicate()
   merged_output = decode_with_fallback(merged_output)
   # Strip a single trailing newline, if one exists, to match the behaviour of
   # subprocess.getstatusoutput.
@@ -64,10 +85,14 @@ def getstatusoutput(command):
   return proc.returncode, merged_output
 
 
-def execute(command, printer=debug):
+def execute(command, printer=debug, timeout=None):
   popen = Popen(command, shell=is_string(command), stdout=PIPE, stderr=STDOUT)
+  start_time = time.time()
   for line in iter(popen.stdout.readline, b""):
     printer("%s", decode_with_fallback(line).strip("\n"))
+    if timeout is not None and time.time() > start_time + timeout:
+      popen.terminate()
+      break
   out = decode_with_fallback(popen.communicate()[0]).strip("\n")
   if out:
     printer("%s", out)

--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -2,8 +2,13 @@ import os
 import os.path
 import sys
 import time
-from subprocess import Popen, PIPE, STDOUT, TimeoutExpired
+from subprocess import Popen, PIPE, STDOUT
 from textwrap import dedent
+try:
+  from subprocess import TimeoutExpired
+except ImportError:
+  class TimeoutExpired(Exception):
+    """Stub exception for Python 2."""
 try:
   from shlex import quote  # Python 3.3+
 except ImportError:

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -5,6 +5,9 @@ except ImportError:
 from alibuild_helpers.cmd import getstatusoutput
 from alibuild_helpers.log import debug
 
+GIT_COMMAND_TIMEOUT_SEC = 120
+"""How many seconds to let any git command execute before being terminated."""
+
 
 def clone_speedup_options():
   """Return a list of options supported by the system git which speed up cloning."""
@@ -25,10 +28,12 @@ def git(args, directory=".", check=True, prompt=True):
   set -e +x
   cd {directory} >/dev/null 2>&1
   {prompt_var} git {args}
-  """.format(directory=quote(directory),
-             args=" ".join(map(quote, args)),
-             # GIT_TERMINAL_PROMPT is only supported in git 2.3+.
-             prompt_var="GIT_TERMINAL_PROMPT=0" if not prompt else ""))
+  """.format(
+    directory=quote(directory),
+    args=" ".join(map(quote, args)),
+    # GIT_TERMINAL_PROMPT is only supported in git 2.3+.
+    prompt_var="GIT_TERMINAL_PROMPT=0" if not prompt else "",
+  ), timeout=GIT_COMMAND_TIMEOUT_SEC)
   if check and err != 0:
     raise RuntimeError("Error {} from git {}: {}".format(err, " ".join(args), output))
   return output if check else (err, output)


### PR DESCRIPTION
We want to avoid waiting for hours in CI if we can't update a git repository.

Add a `timeout=` argument to our `alibuild_helpers.cmd.*` functions and enforce it, at least where feasible, i.e. on Python 3.