### PR TITLE
Safely log git failures in a special log file

### DIFF
--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -1,6 +1,7 @@
 import argparse
 from alibuild_helpers.utilities import format, detectArch
 from alibuild_helpers.utilities import normalise_multiple_options
+from alibuild_helpers.workarea import cleanup_git_log
 import multiprocessing
 
 import re
@@ -380,6 +381,9 @@ def finaliseArgs(args, parser, star):
 
   if args.action in ["build", "init"]:
     args.referenceSources = format(args.referenceSources, workDir=args.workDir)
+    # Do this cleanup as early as possible to avoid false positives due to
+    # stale git logs from previous invocations.
+    cleanup_git_log(args.referenceSources)
 
   if args.action == "build":
     args.configDir = args.configDir

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -17,7 +17,7 @@ from alibuild_helpers.git import git, clone_speedup_options
 from alibuild_helpers.sync import (NoRemoteSync, HttpRemoteSync, S3RemoteSync,
                                    Boto3RemoteSync, RsyncRemoteSync)
 import yaml
-from alibuild_helpers.workarea import updateReferenceRepoSpec
+from alibuild_helpers.workarea import cleanup_git_log, logged_git, updateReferenceRepoSpec
 from alibuild_helpers.log import logger_handler, LogFormatter, ProgressPrint
 from datetime import datetime
 from glob import glob
@@ -75,7 +75,8 @@ def update_git_repos(args, specs, buildOrder, develPkgs):
         else:
             cmd.append(specs[package].get("reference", specs[package]["source"]))
 
-        output = git(cmd, prompt=git_prompt)
+        output = logged_git(package, args.referenceSources,
+                            cmd, ".", prompt=git_prompt, logOutput=False)
         specs[package]["git_refs"] = {
             git_ref: git_hash for git_hash, sep, git_ref
             in (line.partition("\t") for line in output.splitlines()) if sep

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -2,7 +2,7 @@ from alibuild_helpers.git import git
 from alibuild_helpers.utilities import getPackageList, parseDefaults, readDefaults, validateDefaults
 from alibuild_helpers.log import debug, error, warning, banner, info
 from alibuild_helpers.log import dieOnError
-from alibuild_helpers.workarea import updateReferenceRepoSpec
+from alibuild_helpers.workarea import cleanup_git_log, updateReferenceRepoSpec
 
 from os.path import join
 import os.path as path

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -1,4 +1,5 @@
 import codecs
+import errno
 import os
 import os.path
 import tempfile
@@ -9,6 +10,49 @@ except ImportError:
 
 from alibuild_helpers.log import dieOnError, debug, info
 from alibuild_helpers.git import git, clone_speedup_options
+
+FETCH_LOG_NAME = "fetch-log.txt"
+
+
+def cleanup_git_log(referenceSources):
+  """Remove a stale fetch-log.txt.
+
+  You must call this function before running updateReferenceRepoSpec or
+  updateReferenceRepo any number of times. This is not done automatically, so
+  that running those functions in parallel works properly.
+  """
+  try:
+    os.unlink(os.path.join(referenceSources, FETCH_LOG_NAME))
+  except OSError as exc:
+    # Ignore errors when deleting a nonexistent file.
+    dieOnError(exc.errno != errno.ENOENT,
+               "Could not delete stale git log: %s" % exc)
+
+
+def logged_git(package, referenceSources,
+               command, directory, prompt, logOutput=True):
+  """Run a git command, but produce an output file if it fails.
+
+  This is useful in CI, so that we can pick up git failures and show them in
+  the final produced log. For this reason, the file we write in this function
+  must not contain any secrets. We only output the git command we ran, its exit
+  code, and the package name, so this should be safe.
+  """
+  # This might take a long time, so show the user what's going on.
+  info("Git %s for repository for %s...", command[0], package)
+  err, output = git(command, directory=directory, check=False, prompt=prompt)
+  if logOutput:
+    debug(output)
+  if err:
+    with codecs.open(os.path.join(referenceSources, FETCH_LOG_NAME),
+                     "a", encoding="utf-8", errors="replace") as logf:
+      logf.write("Git command for package %r failed.\n"
+                 "Command: git %s\nExit code: %d\n" %
+                 (package, directory, " ".join(command), err))
+  dieOnError(err, "Error during git %s for reference repo for %s." %
+             (command[0], package))
+  info("Done git %s for repository for %s", command[0], package)
+  return output
 
 
 def updateReferenceRepoSpec(referenceSources, p, spec,
@@ -70,24 +114,12 @@ def updateReferenceRepo(referenceSources, p, spec,
     cmd = ["clone", "--bare", spec["source"], referenceRepo]
     if usePartialClone:
       cmd.extend(clone_speedup_options())
-    # This might take a long time, so show the user what's going on.
-    info("Cloning git repository for %s...", spec["package"])
-    git(cmd, prompt=allowGitPrompt)
-    info("Done cloning git repository for %s", spec["package"])
+    logged_git(p, referenceSources, cmd, ".", allowGitPrompt)
   elif fetch:
-    with codecs.open(os.path.join(os.path.dirname(referenceRepo),
-                                  "fetch-log.txt"),
-                     "w", encoding="utf-8", errors="replace") as logf:
-      # This might take a long time, so show the user what's going on.
-      info("Updating git repository for %s...", spec["package"])
-      err, output = git(("fetch", "-f", "--tags", spec["source"],
-                         "+refs/heads/*:refs/heads/*"),
-                        directory=referenceRepo, check=False,
-                        prompt=allowGitPrompt)
-      logf.write(output)
-      debug(output)
-      dieOnError(err, "Error while updating reference repo for %s." % spec["source"])
-      info("Done updating git repository for %s", spec["package"])
+    logged_git(p, referenceSources, (
+      "fetch", "-f", "--tags", spec["source"], "+refs/heads/*:refs/heads/*",
+    ), referenceRepo, allowGitPrompt)
+
   return referenceRepo  # reference is read-write
 
 

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -86,15 +86,17 @@ class WorkareaTestCase(unittest.TestCase):
     @patch("alibuild_helpers.workarea.is_writeable", new=MagicMock(return_value=True))
     def test_reference_sources_created(self, mock_git, mock_makedirs, mock_exists):
         """Check the mirror directory is created when possible."""
+        mock_git.return_value = 0, ""
         mock_exists.side_effect = lambda path: not path.endswith("/aliroot")
         spec = MOCK_SPEC.copy()
         updateReferenceRepoSpec(referenceSources="sw/MIRROR", p="AliRoot",
                                 spec=spec, fetch=True)
         mock_exists.assert_called_with("%s/sw/MIRROR/aliroot" % getcwd())
         mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd())
-        mock_git.assert_called_once_with(["clone", "--bare", spec["source"],
-                                          "%s/sw/MIRROR/aliroot" % getcwd(),
-                                          "--filter=blob:none"], prompt=True)
+        mock_git.assert_called_once_with([
+            "clone", "--bare", spec["source"],
+            "%s/sw/MIRROR/aliroot" % getcwd(), "--filter=blob:none",
+        ], directory=".", check=False, prompt=True)
         self.assertEqual(spec.get("reference"), "%s/sw/MIRROR/aliroot" % getcwd())
 
 


### PR DESCRIPTION
This is useful for CI, as we can show this log to the user if it exists, to indicate build failures due to failed git commands. The log file should not expose secrets to users, as it only contains the package name, git command and its exit code.