### PR TITLE
Abort build when upload conflict on S3 is detected

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -834,12 +834,6 @@ def doBuild(args, parser):
       if "obsolete_tarball" in spec:
         unlink(realpath(spec["obsolete_tarball"]))
         unlink(spec["obsolete_tarball"])
-      # We need to create 2 sets of links, once with the full requires,
-      # once with only direct dependencies, since that's required to
-      # register packages in Alien.
-      createDistLinks(spec, specs, args, syncHelper, "dist", "full_requires")
-      createDistLinks(spec, specs, args, syncHelper, "dist-direct", "requires")
-      createDistLinks(spec, specs, args, syncHelper, "dist-runtime", "full_runtime_requires")
       buildOrder.pop(0)
       packageIterations = 0
       # We can now delete the INSTALLROOT and BUILD directories,
@@ -1135,6 +1129,13 @@ def doBuild(args, parser):
                                                    for dp in updatablePkgs]))
 
     dieOnError(err, buildErrMsg)
+
+    # We need to create 2 sets of links, once with the full requires,
+    # once with only direct dependencies, since that's required to
+    # register packages in Alien.
+    createDistLinks(spec, specs, args, syncHelper, "dist", "full_requires")
+    createDistLinks(spec, specs, args, syncHelper, "dist-direct", "requires")
+    createDistLinks(spec, specs, args, syncHelper, "dist-runtime", "full_runtime_requires")
 
     # Make sure not to upload local-only packages! These might have been
     # produced in a previous run with a read-only remote store.

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -1140,9 +1140,8 @@ def doBuild(args, parser):
 
     # Make sure not to upload local-only packages! These might have been
     # produced in a previous run with a read-only remote store.
-    if spec["revision"].startswith("local"):
-      continue   # Skip upload below.
-    syncHelper.syncToRemote(p, spec)
+    if not spec["revision"].startswith("local"):
+      syncHelper.syncToRemote(p, spec)
 
   banner("Build of %s successfully completed on `%s'.\n"
          "Your software installation is at:"

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -148,8 +148,6 @@ def createDistLinks(spec, specs, args, syncHelper, repoType, requiresType):
   for g in [ links[i:i+10] for i in range(0, len(links), 10) ]:
     execute(" && ".join([cmd] + g))
 
-  syncHelper.syncDistLinksToRemote(target)
-
 
 def storeHashes(package, specs, isDevelPkg, considerRelocation):
   """Calculate various hashes for package, and store them in specs[package].

--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -530,7 +530,7 @@ class Boto3RemoteSync:
   def syncDistLinksToRemote(self, link_dir):
     if not self.writeStore:
       return
-    debug("Syncing dist symlinks to S3")
+    debug("Syncing dist symlinks to S3 from %s", link_dir)
 
     symlinks = []
     for fname in os.listdir(os.path.join(self.workdir, link_dir)):

--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -10,7 +10,7 @@ import requests
 from requests.exceptions import RequestException
 
 from alibuild_helpers.cmd import execute
-from alibuild_helpers.log import debug, warning, error, dieOnError
+from alibuild_helpers.log import debug, error, dieOnError
 from alibuild_helpers.utilities import format, resolve_store_path, resolve_links_path
 
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -46,10 +46,6 @@ def tarball_name(spec):
 TAR_NAMES = tarball_name(GOOD_SPEC), tarball_name(BAD_SPEC), tarball_name(MISSING_SPEC)
 
 
-def dist_dir(spec):
-    return "/sw/dist/{package}/{package}-{version}-{revision}".format(**spec)
-
-
 class MockRequest:
     def __init__(self, j, simulate_err=False):
         self.j = j

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -171,6 +171,8 @@ class SyncTestCase(unittest.TestCase):
 
 
 @unittest.skipIf(sys.version_info < (3, 6), "python >= 3.6 is required for boto3")
+@patch("alibuild_helpers.log.error", new=MagicMock())
+@patch("alibuild_helpers.sync.Boto3RemoteSync._s3_init", new=MagicMock())
 class Boto3TestCase(unittest.TestCase):
     """Check the b3:// remote is working properly."""
 
@@ -256,11 +258,10 @@ class Boto3TestCase(unittest.TestCase):
     @patch("glob.glob", new=MagicMock(return_value=[]))
     @patch("os.listdir", new=MagicMock(return_value=[]))
     @patch("os.makedirs", new=MagicMock())
-    # file does not exist locally: force download
+    # Pretend file does not exist locally to force download.
     @patch("os.path.exists", new=MagicMock(return_value=False))
     @patch("os.path.isfile", new=MagicMock(return_value=False))
     @patch("os.path.islink", new=MagicMock(return_value=False))
-    @patch("alibuild_helpers.sync.Boto3RemoteSync._s3_init", new=MagicMock())
     @patch("alibuild_helpers.sync.execute", new=MagicMock(return_value=0))
     def test_tarball_download(self):
         """Test boto3 behaviour when downloading tarballs from the remote."""
@@ -282,8 +283,6 @@ class Boto3TestCase(unittest.TestCase):
         b3sync.s3.download_file.assert_not_called()
 
     @patch("os.readlink", new=MagicMock(return_value="dummy path"))
-    @patch("alibuild_helpers.log.error", new=MagicMock())
-    @patch("alibuild_helpers.sync.Boto3RemoteSync._s3_init", new=MagicMock())
     def test_tarball_upload(self):
         """Test boto3 behaviour when building packages for upload locally."""
         b3sync = sync.Boto3RemoteSync(
@@ -323,8 +322,6 @@ class Boto3TestCase(unittest.TestCase):
     ))
     @patch("os.readlink", new=MagicMock(return_value="dummy path"))
     @patch("os.path.islink", new=MagicMock(return_value=True))
-    @patch("alibuild_helpers.log.error", new=MagicMock())
-    @patch("alibuild_helpers.sync.Boto3RemoteSync._s3_init", new=MagicMock())
     def test_dist_links_upload(self):
         """Make sure dist links are uploaded properly when possible."""
         b3sync = sync.Boto3RemoteSync(

--- a/tox.ini
+++ b/tox.ini
@@ -61,43 +61,56 @@ changedir = {envtmpdir}
 commands =
     # The first coverage command shouldn't have an -a, so we completely replace
     # the coverage info from the last run.
-    coverage run {envbindir}/aliBuild analytics off
+    coverage run --source={toxinidir} {toxinidir}/aliBuild analytics off
     test -e .config/alibuild/disable-analytics
     test ! -e .config/alibuild/analytics-uuid
-    coverage run -a {envbindir}/aliBuild analytics on
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild analytics on
     test ! -e .config/alibuild/disable-analytics
     test -e .config/alibuild/analytics-uuid
-    coverage run -a {envbindir}/aliBuild analytics off
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild analytics off
     test -e .config/alibuild/disable-analytics
     test -e .config/alibuild/analytics-uuid
 
-    coverage run -a {envbindir}/aliBuild version
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild version
 
-    coverage run -a -m unittest discover {toxinidir}/tests
+    coverage run --source={toxinidir} -a -m unittest discover {toxinidir}/tests
 
     git clone -b O2-v1.3.0 --depth 1 https://github.com/alisw/alidist
 
-    coverage run -a {envbindir}/aliBuild -a slc7_x86-64 -z test-init init zlib
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild -a slc7_x86-64 -z test-init init zlib
     # This command is expected to fail, but run it for the coverage anyway.
     # A leading "-" means tox ignores the exit code.
-    - coverage run -a {envbindir}/aliBuild build non-existing -a slc7_x86-64 --no-system --disable GCC-Toolchain
+    - coverage run --source={toxinidir} -a {toxinidir}/aliBuild build non-existing -a slc7_x86-64 --no-system --disable GCC-Toolchain
 
     # TODO: do we need these? This seems to be at least partially covered by
     # unit tests in tests/tests_parseRecipe.py.
-    sh -c 'coverage run -a {envbindir}/aliBuild -c {toxinidir}/tests/testdist build broken1 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Header missing"'
-    sh -c 'coverage run -a {envbindir}/aliBuild -c {toxinidir}/tests/testdist build broken2 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Empty recipe"'
-    sh -c 'coverage run -a {envbindir}/aliBuild -c {toxinidir}/tests/testdist build broken3 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Unable to parse"'
-    sh -c 'coverage run -a {envbindir}/aliBuild -c {toxinidir}/tests/testdist build broken4 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Malformed header"'
-    sh -c 'coverage run -a {envbindir}/aliBuild -c {toxinidir}/tests/testdist build broken5 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Missing package"'
-    sh -c 'coverage run -a {envbindir}/aliBuild -c {toxinidir}/tests/testdist build broken6 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "while scanning a quoted scalar"'
-    sh -c 'coverage run -a {envbindir}/aliBuild -c {toxinidir}/tests/testdist build broken7 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Malformed entry prefer_system"'
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build broken1 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Header missing"'
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build broken2 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Empty recipe"'
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build broken3 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Unable to parse"'
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build broken4 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Malformed header"'
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build broken5 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Missing package"'
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build broken6 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "while scanning a quoted scalar"'
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build broken7 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Malformed entry prefer_system"'
 
-    coverage run -a {envbindir}/aliBuild build zlib -a slc7_x86-64 --no-system --disable GCC-Toolchain
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild build zlib -a slc7_x86-64 --no-system --disable GCC-Toolchain
     alienv -a slc7_x86-64 q
     alienv -a slc7_x86-64 setenv zlib/latest -c bash -c '[[ $LD_LIBRARY_PATH == */zlib/* ]]'
-    coverage run -a {envbindir}/aliBuild -a slc7_x86-64 doctor AliPhysics
-    coverage run -a {envbindir}/aliBuild -a slc7_x86-64 build zlib --dry-run
-    coverage run -a {envbindir}/aliBuild --aggressive-cleanup --docker -a slc7_x86-64 --always-prefer-system -d build zlib
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild -a slc7_x86-64 doctor AliPhysics
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild -a slc7_x86-64 build zlib --dry-run
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild --aggressive-cleanup --docker -a slc7_x86-64 --always-prefer-system -d build zlib
     # Test for devel packages
-    coverage run -a {envbindir}/aliBuild init zlib
-    coverage run -a {envbindir}/aliBuild --aggressive-cleanup --docker -a slc7_x86-64 --always-prefer-system -d build zlib
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild init zlib
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild --aggressive-cleanup --docker -a slc7_x86-64 --always-prefer-system -d build zlib
+
+[coverage:run]
+branch = True
+omit =
+    */.tox/*/lib/*
+
+[coverage:report]
+exclude_lines =
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:


### PR DESCRIPTION
If two aliBuild instances are building the same package at the same time and uploading it to S3, make sure that only one can upload at a time, and abort the other one.

There are probably ways to make aliBuild recover more intelligently from conflicts, but this commit only includes basic conflict detection.