### PR TITLE
Use setuptools_scm to single-source an always-valid version number

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/setup-python@v3
         with:
           python-version: 3.x
-      - name: Replace the hard-coded version number
-        run: sed -i "s/LAST_TAG/${GITHUB_REF#refs/tags/}/g" alibuild_helpers/__init__.py
       - name: Build the Python distribution
         run: python setup.py sdist
       - name: Publish distribution to PyPI

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ _site
 # For unit tests
 build.log
 .tox
+# For setuptools_scm
+alibuild_helpers/_version.py

--- a/alibuild_helpers/__init__.py
+++ b/alibuild_helpers/__init__.py
@@ -1,9 +1,19 @@
 # This file is needed to package build_template.sh.
 
-# Versions should comply with PEP440. For a discussion on single-sourcing the
-# version across setup.py and the project code, see
-# https://packaging.python.org/en/latest/single_source_version.html
-#
-# LAST_TAG is actually a placeholder which will be automatically replaced by
-# the release-alibuild pipeline in jenkins whenever we need a new release.
-__version__ = 'LAST_TAG'
+# Single-source a PEP440-compliant version using setuptools_scm.
+try:
+    # This is an sdist or wheel, and it's properly installed.
+    from alibuild_helpers._version import __version__
+except ImportError:
+    # We're probably running directly from a source checkout.
+    try:
+        from setuptools_scm import get_version
+    except ImportError:
+        __version__ = '(could not detect version)'
+    else:
+        try:
+            __version__ = get_version()
+        except LookupError:
+            __version__ = '(could not detect version)'
+        finally:
+            del get_version

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
-from textwrap import dedent
 import sys
 
 here = path.abspath(path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@ from setuptools import setup, find_packages
 # To use a consistent encoding
 from codecs import open
 from os import path
+from textwrap import dedent
 import sys
-import alibuild_helpers
 
 here = path.abspath(path.dirname(__file__))
 
@@ -24,8 +24,6 @@ if sys.version_info >= (3, 6):
 
 setup(
     name='alibuild',
-
-    version=alibuild_helpers.__version__,
 
     description='ALICE Build Tool',
     long_description=long_description,
@@ -73,6 +71,12 @@ setup(
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:
     #   py_modules=["my_module"],
+
+    # Single-source our package version using setuptools_scm. This makes it
+    # PEP440-compliant, and it always references the alibuild commit that
+    # aliBuild was built from.
+    use_scm_version={'write_to': 'alibuild_helpers/_version.py'},
+    setup_requires=['setuptools_scm'],
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,13 @@ setup(
     # PEP440-compliant, and it always references the alibuild commit that
     # aliBuild was built from.
     use_scm_version={'write_to': 'alibuild_helpers/_version.py'},
-    setup_requires=['setuptools_scm'],
+    setup_requires=[
+        # The 6.* series removed support for Python 2.7.
+        'setuptools_scm<6.0.0' if sys.version_info < (3, 0) else
+        # The 7.* series removed support for Python 3.6.
+        'setuptools_scm<7.0.0' if sys.version_info < (3, 7) else
+        'setuptools_scm'
+    ],
 
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed. For an analysis of "install_requires" vs pip's


### PR DESCRIPTION
The latest pip versions fail to install a source checkout if its version is set to `LAST_TAG`, which we do for all untagged commits.

Use setuptools_scm instead, so that we always have a valid, PEP440-compliant version number, even for commits in between tags.