### PR TITLE
Remove `star()` function for experiment prefix

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -17,7 +17,7 @@ from alibuild_helpers.doctor import doDoctor
 from alibuild_helpers.deps import doDeps
 from alibuild_helpers.log import info, warning, debug, logger, error
 from alibuild_helpers.utilities import detectArch
-from alibuild_helpers.build import doBuild, star
+from alibuild_helpers.build import doBuild
 
 
 def doMain(args, parser):
@@ -85,7 +85,7 @@ def doMain(args, parser):
 
 
 if __name__ == "__main__":
-  args, parser = doParseArgs(star())
+  args, parser = doParseArgs()
 
   # This is valid for everything
   logger.setLevel(logging.DEBUG if args.debug else logging.INFO)

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -5,7 +5,7 @@ from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, error, info, banner, warning
 from alibuild_helpers.log import dieOnError
 from alibuild_helpers.cmd import execute, getstatusoutput, DockerRunner, BASH, install_wrapper_script
-from alibuild_helpers.utilities import star, prunePaths
+from alibuild_helpers.utilities import prunePaths
 from alibuild_helpers.utilities import resolve_store_path
 from alibuild_helpers.utilities import format, parseDefaults, readDefaults
 from alibuild_helpers.utilities import getPackageList
@@ -293,10 +293,10 @@ def hash_local_changes(directory):
     debug("Command %s returned %d", cmd, err)
     dieOnError(err, "Unable to detect source code changes.")
   except UntrackedChangesError:
-    warning("You have untracked changes in %s, so %sBuild cannot detect "
+    warning("You have untracked changes in %s, so aliBuild cannot detect "
             "whether it needs to rebuild the package. Therefore, the package "
             "is being rebuilt unconditionally. Please use 'git add' and/or "
-            "'git commit' to track your changes in git.", directory, star())
+            "'git commit' to track your changes in git.", directory)
     # If there are untracked changes, always rebuild (hopefully incrementally)
     # and let CMake figure out what needs to be rebuilt. Force a rebuild by
     # changing the hash to something basically random.
@@ -341,10 +341,9 @@ def doBuild(args, parser):
   prunePaths(workDir)
 
   if not exists(args.configDir):
-    error('Cannot find %sdist recipes under directory "%s".\n'
+    error('Cannot find alidist recipes under directory "%s".\n'
           'Maybe you need to "cd" to the right directory or '
-          'you forgot to run "%sBuild init"?',
-          star(), args.configDir, star())
+          'you forgot to run "aliBuild init"?', args.configDir)
     return 1
 
   _, value = git(("symbolic-ref", "-q", "HEAD"), directory=args.configDir, check=False)
@@ -368,8 +367,8 @@ def doBuild(args, parser):
 
   debug("Building for architecture %s", args.architecture)
   debug("Number of parallel builds: %d", args.jobs)
-  debug("Using %sBuild from %sbuild@%s recipes in %sdist@%s",
-        star(), star(), __version__, star(), os.environ["ALIBUILD_ALIDIST_HASH"])
+  debug("Using aliBuild from alibuild@%s recipes in alidist@%s",
+        __version__, os.environ["ALIBUILD_ALIDIST_HASH"])
 
   install_wrapper_script("git", workDir)
 
@@ -403,8 +402,8 @@ def doBuild(args, parser):
 
   if failed:
     error("The following packages are system requirements and could not be found:\n\n- %s\n\n"
-          "Please run:\n\n\t%sDoctor --defaults %s %s\n\nto get a full diagnosis.",
-          "\n- ".join(sorted(list(failed))), star(), args.defaults, args.pkgname.pop())
+          "Please run:\n\n\taliDoctor --defaults %s %s\n\nto get a full diagnosis.",
+          "\n- ".join(sorted(list(failed))), args.defaults, args.pkgname.pop())
     return 1
 
   for x in specs.values():
@@ -413,8 +412,8 @@ def doBuild(args, parser):
     x["runtime_requires"] = [r for r in x["runtime_requires"] if not r in args.disable]
 
   if systemPackages:
-    banner("%sBuild can take the following packages from the system and will not build them:\n  %s",
-           star(), ", ".join(systemPackages))
+    banner("aliBuild can take the following packages from the system and will not build them:\n  %s",
+           ", ".join(systemPackages))
   if ownPackages:
     banner("The following packages cannot be taken from the system and will be built:\n  %s",
            ", ".join(ownPackages))
@@ -469,10 +468,10 @@ def doBuild(args, parser):
     banner("You have packages in development mode.\n"
            "This means their source code can be freely modified under:\n\n"
            "  %s/<package_name>\n\n"
-           "%sBuild does not automatically update such packages to avoid work loss.\n"
+           "aliBuild does not automatically update such packages to avoid work loss.\n"
            "In most cases this is achieved by doing in the package source directory:\n\n"
            "  git pull --rebase\n",
-           os.getcwd(), star())
+           os.getcwd())
 
   # Clone/update repos
   update_git_repos(args, specs, buildOrder, develPkgs)
@@ -490,10 +489,10 @@ def doBuild(args, parser):
                "Found a directory called {package} here, but we're not "
                "expecting any code for the package {package}. If this is a "
                "mistake, please rename the {package} directory or use the "
-               "'--no-local {package}' option. If {star}Build should pick up "
+               "'--no-local {package}' option. If aliBuild should pick up "
                "source code from this directory, add a 'source:' key to "
                "alidist/{recipe}.sh instead."
-               .format(package=p, recipe=p.lower(), star=star()))
+               .format(package=p, recipe=p.lower()))
     if "source" in spec:
       # Tag may contain date params like %(year)s, %(month)s, %(day)s, %(hour).
       spec["tag"] = resolve_tag(spec)

--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -11,7 +11,7 @@ from requests.exceptions import RequestException
 
 from alibuild_helpers.cmd import execute
 from alibuild_helpers.log import debug, warning, error, dieOnError
-from alibuild_helpers.utilities import format, star, resolve_store_path, resolve_links_path
+from alibuild_helpers.utilities import format, resolve_store_path, resolve_links_path
 
 
 class NoRemoteSync:
@@ -395,7 +395,7 @@ class Boto3RemoteSync:
                              aws_secret_access_key=os.environ["AWS_SECRET_ACCESS_KEY"])
     except KeyError:
       error("you must pass the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env "
-            "variables to %sBuild in order to use the S3 remote store", star())
+            "variables to aliBuild in order to use the S3 remote store")
       sys.exit(1)
 
   def _s3_listdir(self, dirname):

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -23,9 +23,6 @@ class SpecError(Exception):
 
 asList = lambda x : x if type(x) == list else [x]
 
-def star():
-  return re.sub("build.*$", "", basename(sys.argv[0]).lower())
-
 
 def resolve_store_path(architecture, spec_hash):
   """Return the path where a tarball with the given hash is to be stored.

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -93,7 +93,7 @@ class ArgsTestCase(unittest.TestCase):
       (alibuild_helpers.args.DEFAULT_WORK_DIR,
        alibuild_helpers.args.DEFAULT_CHDIR) = env or ("sw", ".")
       with patch.object(sys, "argv", ["alibuild"] + shlex.split(cmd)):
-        args, parser = doParseArgs("ali")
+        args, parser = doParseArgs()
         args = vars(args)
         for k, v in effects:
           self.assertEqual(args[k], v)
@@ -105,7 +105,7 @@ class ArgsTestCase(unittest.TestCase):
     for (cmd, calls) in PARSER_ERRORS.items():
       mock_print.mock_calls = []
       with patch.object(sys, "argv", ["alibuild"] + shlex.split(cmd)):
-        self.assertRaises(FakeExit, lambda : doParseArgs("ali"))
+        self.assertRaises(FakeExit, doParseArgs)
         self.assertEqual(mock_print.mock_calls, calls)
 
   def test_validArchitectures(self):

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -192,6 +192,7 @@ def dummy_exists(x):
        new=MagicMock(return_value=["--filter=blob:none"]))
 @patch("alibuild_helpers.workarea.clone_speedup_options",
        new=MagicMock(return_value=["--filter=blob:none"]))
+@patch("alibuild_helpers.build.BASH", new="/bin/bash")
 class BuildTestCase(unittest.TestCase):
     @patch("alibuild_helpers.analytics", new=MagicMock())
     @patch("requests.Session.get", new=MagicMock())

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -10,6 +10,7 @@ from alibuild_helpers.cmd import execute, DockerRunner
 import unittest
 
 
+@mock.patch("alibuild_helpers.cmd.BASH", new="/bin/bash")
 class CmdTestCase(unittest.TestCase):
     @mock.patch("alibuild_helpers.cmd.debug")
     def test_execute(self, mock_debug):


### PR DESCRIPTION
Instead of using a function to prefix `ali` to everything, just hardcode the prefix.

On Guix, Python packages are installed with a wrapper script, and the aliBuild executable is called `.aliBuild-real`, which breaks this and `aliBuild init` tries to clone `https://github.com/alisw/.alidist`.