### PR TITLE
Automatically use S3 remote on Ubuntu 22.04

### DIFF
--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -341,8 +341,8 @@ On Linux, x86-64:
    RHEL6 / SLC6 compatible: slc6_x86-64
    RHEL7 / CC7 compatible: slc7_x86-64
    RHEL8 / CC8 compatible: slc8_x86-64
-   Ubuntu 18.04 compatible: ubuntu1804_x86-64
    Ubuntu 20.04 compatible: ubuntu2004_x86-64
+   Ubuntu 22.04 compatible: ubuntu2204_x86-64
    Fedora 33 compatible: fedora33_x86-64
    Fedora 34 compatible: fedora34_x86-64
 
@@ -354,7 +354,7 @@ On Mac, x86-64:
    Big Sur: osx_arm64
 """
 
-S3_SUPPORTED_ARCHS = "slc7_x86-64", "slc8_x86-64", "ubuntu2004_x86-64"
+S3_SUPPORTED_ARCHS = "slc7_x86-64", "slc8_x86-64", "ubuntu2004_x86-64", "ubuntu2204_x86-64"
 
 def finaliseArgs(args, parser):
 


### PR DESCRIPTION
I've got a working `ubuntu2204-builder` container set up, and I've seeded S3 with initial builds up to O2. There's also a Jenkins job building nightlies on Ubuntu 22.04, just like on Ubuntu 20.04.

Overall, I'd say everything is in place for aliBuild to start automatically using precompiled tarballs on Ubuntu 22.04.

Unfortunately, this will change the behaviour of aliBuild slightly on Ubuntu 22.04: previously, system packages would be used if possible; after this change is applied, aliBuild defaults to `--no-system` instead, so that it can make best use of precompiled tarballs. To get back the previous behaviour, pass the `--no-remote-store` option to `aliBuild build`.