### PR TITLE
Protect against reusing partially-uploaded tarballs

### DIFF
--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -283,6 +283,7 @@ class Boto3TestCase(unittest.TestCase):
     ))
     @patch("os.readlink", new=MagicMock(return_value="dummy path"))
     @patch("os.path.islink", new=MagicMock(return_value=True))
+    @patch("os.stat", new=MagicMock(return_value=MagicMock(st_size=42)))
     def test_tarball_upload(self):
         """Test boto3 behaviour when building packages for upload locally."""
         b3sync = sync.Boto3RemoteSync(


### PR DESCRIPTION
Previously, if a package's symlinks were uploaded partially (e.g. not all dist symlinks uploaded, but the "main" symlink was present), and that package's hash matched what we need, then its revision number would be reused. This would then fail on upload, as aliBuild would detect a conflict with the partially-uploaded dist symlinks.

Relying on the fact that we upload the tarball last, after any symlinks, we can detect that this has happened by not reusing revision numbers for which we do not already have a tarball available. The `syncToLocal` function should download any tarball with the right hash, so if one is not available even though a symlink's hash matches, then we know it's probably from a partial upload and we must not reuse its revision number.

Draft since I've not tested this properly so far, I've only run some unittests locally.

@davidrohr this should fix the problem seen in the WeeklyO2 build last night. Though the specific partial upload of QC that was causing problems is now cleaned up -- I must've missed some files last night -- and a rebuild today went fine.