### PR TITLE
Warn about uncommitted files in final summary

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,7 @@ allowlist_externals =
     sh
     git
     test
+    touch
 deps =
     py27: mock
     coverage
@@ -101,6 +102,10 @@ commands =
     # Test for devel packages
     coverage run --source={toxinidir} -a {toxinidir}/aliBuild init zlib
     coverage run --source={toxinidir} -a {toxinidir}/aliBuild --aggressive-cleanup --docker -a slc7_x86-64 --always-prefer-system -d build zlib
+    # Test that we complain if we have a devel package with an untracked file
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild init zlib
+    touch zlib/foo
+    coverage run --source={toxinidir} -a {toxinidir}/aliBuild -a slc7_x86-64 --no-system --disable GCC-Toolchain build zlib
 
 [coverage:run]
 branch = True


### PR DESCRIPTION
Warn about uncommitted files in final summary

Too many times rebuilds have gone unnoticed because the per package
warning gets lost in the debug output. This tries to improve the issue
by adding a summary at the end with the list of directories containing
untracked files.
