### PR TITLE
Make test_git work for priveleged users

### DIFF
--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -43,5 +43,5 @@ class GitWrapperTestCase(unittest.TestCase):
     def test_git_private_repo(self):
         """Check we get the right exception when credentials are required."""
         self.assertRaises(RuntimeError, git, (
-            "ls-remote", "-ht", PRIVATE_REPO,
+            "-c", "credential.helper=", "ls-remote", "-ht", PRIVATE_REPO,
         ), prompt=False)


### PR DESCRIPTION
Make test_git work for priveleged users

The test for private repos will actually succeed if one has
a credential.store which allows you to access the repository.
