### PR TITLE
Fix hashing on Python 3.12

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,14 +21,15 @@ jobs:
     runs-on: ubuntu-20.04
 
     strategy:
+      fail-fast: false   # continue executing other checks if one fails
       matrix:
         python-version:
           - '3.6.8'   # slc7, slc8 and cs8 containers
-          - '3.7'
-          - '3.8'
-          - '3.9'
-          - '3.10'
+          - '3.8.10'  # ubuntu2004 container
+          - '3.9.16'  # slc9 container
+          - '3.10.6'  # ubuntu2204 container
           - '3.11'
+          - '3.12'
 
     steps:
       - uses: actions/checkout@v3
@@ -68,6 +69,7 @@ jobs:
     runs-on: macos-latest
 
     strategy:
+      fail-fast: false   # continue executing other checks if one fails
       matrix:
         python-version:
           - '3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,16 @@ classifiers = [
     'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
     'Programming Language :: Python :: 2.7',   # slc6
     'Programming Language :: Python :: 3.6',   # slc7, slc8, cs8
-    'Programming Language :: Python :: 3.8',   # MacOS
-    'Programming Language :: Python :: 3.9',   # alma9
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
+    'Programming Language :: Python :: 3.8',   # ubuntu2004
+    'Programming Language :: Python :: 3.9',   # slc9
+    'Programming Language :: Python :: 3.10',  # ubuntu2204
+    'Programming Language :: Python :: 3.11',  # MacOS
+    'Programming Language :: Python :: 3.12',  # MacOS
 ]
 
 dependencies = [
   'pyyaml',
-  'requests', 
+  'requests',
   'distro',
   'jinja2',
   'boto3',

--- a/setup.py
+++ b/setup.py
@@ -54,10 +54,11 @@ setup(
         # that you indicate whether you support Python 2, Python 3 or both.
         'Programming Language :: Python :: 2.7',   # slc6
         'Programming Language :: Python :: 3.6',   # slc7, slc8, cs8
-        'Programming Language :: Python :: 3.8',   # MacOS
-        'Programming Language :: Python :: 3.9',   # alma9
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.8',   # ubuntu2004
+        'Programming Language :: Python :: 3.9',   # slc9
+        'Programming Language :: Python :: 3.10',  # ubuntu2204
+        'Programming Language :: Python :: 3.11',  # MacOS
+        'Programming Language :: Python :: 3.12',  # MacOS
     ],
 
     # What does your project relate to?

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -276,10 +276,10 @@ class BuildTestCase(unittest.TestCase):
         clone_args, clone_dir, clone_check = GIT_CLONE_ZLIB_ARGS
         fetch_args, fetch_dir, fetch_check = GIT_FETCH_ROOT_ARGS
         common_calls = [
+            call(("rev-parse", "HEAD"), args.configDir),
             call(list(clone_args), directory=clone_dir, check=clone_check, prompt=False),
             call(["ls-remote", "--heads", "--tags", args.referenceSources + "/zlib"],
                  directory=".", check=False, prompt=False),
-            call(["clone", "--bare", "https://github.com/star-externals/zlib", "/sw/MIRROR/zlib", "--filter=blob:none"]),
             call(["ls-remote", "--heads", "--tags", args.referenceSources + "/root"],
                  directory=".", check=False, prompt=False),
         ]
@@ -290,7 +290,7 @@ class BuildTestCase(unittest.TestCase):
         self.assertEqual(exit_code, 0)
         mock_debug.assert_called_with("Everything done")
         self.assertEqual(mock_git_git.call_count, len(common_calls))
-        mock_git_git.has_calls(common_calls)
+        mock_git_git.assert_has_calls(common_calls, any_order=True)
 
         # Force fetching repos
         mock_git_git.reset_mock()
@@ -303,9 +303,9 @@ class BuildTestCase(unittest.TestCase):
         # We can't compare directly against the list of calls here as they
         # might happen in any order.
         self.assertEqual(mock_git_git.call_count, len(common_calls) + 1)
-        mock_git_git.has_calls(common_calls + [
-            call(fetch_args, directory=fetch_dir, check=fetch_check),
-        ])
+        mock_git_git.assert_has_calls(common_calls + [
+            call(list(fetch_args), directory=fetch_dir, check=fetch_check, prompt=False),
+        ], any_order=True)
 
     def test_hashing(self):
         """Check that the hashes assigned to packages remain constant."""

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -60,7 +60,7 @@ class WorkareaTestCase(unittest.TestCase):
         updateReferenceRepoSpec(referenceSources="sw/MIRROR", p="AliRoot",
                                 spec=spec, fetch=True)
         mock_exists.assert_called_with("%s/sw/MIRROR/aliroot" % getcwd())
-        mock_exists.has_calls([])
+        mock_exists.assert_has_calls([])
         mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd())
         mock_git.assert_called_once_with([
             "fetch", "-f", "--tags", spec["source"], "+refs/heads/*:refs/heads/*",

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.20
-envlist = lint, py{27, 36, 37, 38, 39, 310, 311}, darwin
+envlist = lint, py{27, 36, 37, 38, 39, 310, 311, 312, 313}, darwin
 
 [gh-actions]
 # The "lint" job is run separately.
@@ -12,6 +12,8 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
+    3.13: py313
 
 [testenv:lint]
 # Warning: This environment inherits settings from the main [testenv] section.


### PR DESCRIPTION
Python 3.12 changes the default string representation of OrderedDicts, which aliBuild relies upon (this is obviously far from ideal, but we're stuck with it).

This patch hashes OrderedDicts in their old representation, to maintain hash compatibility between python<3.12 and python==3.12.

This saves e.g. Mac users from having to rebuild their entire sw directory when upgrading from python@3.11 to python@3.12 using brew.

Hashes are checked using unittests, so unittests passing should mean that hashes are computed exactly the same as before. (I found this issue by running the usual unittests on python3.12.) Take this opportunity to add a CI check under python3.12 to this repo.