### PR TITLE
[O2-4412] Dynamically compute optional dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = 'alibuild'
-dynamic = ['readme', 'version']
+dynamic = ['readme', 'version', 'optional-dependencies']
 description = 'ALICE Build Tool'
 keywords = ['HEP', 'ALICE']
 license = {text = 'GPL'}


### PR DESCRIPTION
Otherwise installation fails with:
```
 _MissingDynamic: `optional-dependencies` defined outside of `pyproject.toml` is ignored.
```