### PR TITLE
Allow users to specify build comments

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -60,7 +60,7 @@ def doMain(args, parser):
 
   if args.action == "version":
     print("aliBuild version: {version} ({arch})".format(
-      version=__version__, arch=args.architecture or "unknown"))
+      version=__version__ or "unknown", arch=args.architecture or "unknown"))
     sys.exit(0)
 
   if args.action == "doctor":
@@ -91,7 +91,7 @@ if __name__ == "__main__":
   logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
 
   os.environ["ALIBUILD_ANALYTICS_ID"] = "UA-77346950-1"
-  os.environ["ALIBUILD_VERSION"] = __version__
+  os.environ["ALIBUILD_VERSION"] = __version__ or ""
   if args.action == "analytics":
     if args.state == "off":
       disable_analytics()

--- a/alibuild_helpers/__init__.py
+++ b/alibuild_helpers/__init__.py
@@ -9,13 +9,13 @@ except ImportError:
     try:
         from setuptools_scm import get_version
     except ImportError:
-        __version__ = '(could not detect version)'
+        __version__ = None
     else:
         import os.path
         source_root = os.path.join(os.path.dirname(__file__), os.path.pardir)
         try:
             __version__ = get_version(root=source_root)
         except LookupError:
-            __version__ = '(could not detect version)'
+            __version__ = None
         finally:
             del get_version, source_root

--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -440,9 +440,7 @@ def finaliseArgs(args, parser):
     if args.docker and not args.dockerImage:
       args.dockerImage = "registry.cern.ch/alisw/%s-builder" % args.architecture.split("_")[0]
 
-  if args.action in ("build", "doctor"):
-    args.configDir = args.configDir
-
+  if "annotate" in args:
     for comment_assignment in args.annotate:
       if "=" not in comment_assignment:
         parser.error("--annotate takes arguments of the form PACKAGE=COMMENT")
@@ -451,6 +449,9 @@ def finaliseArgs(args, parser):
       for package, _, comment
       in (assignment.partition("=") for assignment in args.annotate)
     }
+
+  if args.action in ("build", "doctor"):
+    args.configDir = args.configDir
 
     # On selected platforms, caching is active by default
     if args.architecture in S3_SUPPORTED_ARCHS and not args.preferSystem and not args.no_remote_store:

--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -105,6 +105,12 @@ def doParseArgs():
                                   "same effect as adding 'force_rebuild: true' to its recipe "
                                   "in CONFIGDIR. You can specify this option multiple times or "
                                   "separate multiple arguments with commas."))
+  build_parser.add_argument("--annotate", default=[], action="append", metavar="PACKAGE=COMMENT",
+                            help=("Store COMMENT in the build metadata for PACKAGE. This option "
+                                  "can be given multiple times, if you want to store comments "
+                                  "in multiple packages. The comment will only be stored if "
+                                  "PACKAGE is compiled or downloaded during this run; if it "
+                                  "already exists, this does not happen."))
 
   build_docker = build_parser.add_argument_group(title="Build inside a container", description="""\
   Builds can be done inside a Docker container, to make it easier to get a
@@ -436,6 +442,15 @@ def finaliseArgs(args, parser):
 
   if args.action in ("build", "doctor"):
     args.configDir = args.configDir
+
+    for comment_assignment in args.annotate:
+      if "=" not in comment_assignment:
+        parser.error("--annotate takes arguments of the form PACKAGE=COMMENT")
+    args.annotate = {
+      package: comment
+      for package, _, comment
+      in (assignment.partition("=") for assignment in args.annotate)
+    }
 
     # On selected platforms, caching is active by default
     if args.architecture in S3_SUPPORTED_ARCHS and not args.preferSystem and not args.no_remote_store:

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -444,6 +444,9 @@ def create_provenance_info(package, specs, args):
       "hash": spec["hash"],
     }
 
+  def dependency_list(key):
+    return [spec_info(specs[dep]) for dep in specs[package].get(key, ())]
+
   return json.dumps({
     "comment": args.annotate.get(package),
     "alibuild_version": __version__,
@@ -453,9 +456,16 @@ def create_provenance_info(package, specs, args):
     "architecture": args.architecture,
     "defaults": args.defaults,
     "package": spec_info(specs[package]),
-    "dependencies": [
-      spec_info(specs[dep]) for dep in specs[package].get("full_requires", ())
-    ],
+    "dependencies": {
+      "direct": {
+        "build": dependency_list("build_requires"),
+        "runtime": dependency_list("runtime_requires"),
+      },
+      "recursive": {  # includes direct deps and deps' deps
+        "build": dependency_list("full_build_requires"),
+        "runtime": dependency_list("full_runtime_requires"),
+      },
+    },
   })
 
 

--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -77,8 +77,8 @@ fi
 mkdir -p "$INSTALLROOT" "$BUILDROOT" "$BUILDDIR" "$WORK_DIR/INSTALLROOT/$PKGHASH/$PKGPATH"
 
 cd "$WORK_DIR/INSTALLROOT/$PKGHASH"
-cat <<\EOF > "$INSTALLROOT/.full-dependencies"
-%(dependenciesJSON)s
+cat > "$INSTALLROOT/.meta.json" <<\EOF
+%(provenance)s
 EOF
 
 # Add "source" command for dependencies to init.sh.
@@ -207,8 +207,8 @@ source_up
 unset DYLD_LIBRARY_PATH
 EOF
 
-cat <<\EOF > "$INSTALLROOT/.full-dependencies"
-%(dependenciesJSON)s
+cat > "$INSTALLROOT/.meta.json" <<\EOF
+%(provenance)s
 EOF
 
 cd "$WORK_DIR/INSTALLROOT/$PKGHASH/$PKGPATH"

--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -34,6 +34,7 @@ PARSER_ERRORS = {
   "build zlib --architecture foo": ARCHITECTURE_ERROR,
   "build --force-unknown-architecture zlib --remote-store rsync://test1.local/::rw --write-store rsync://test2.local/::rw ": [call('cannot specify ::rw and --write-store at the same time')],
   "build zlib -a osx_x86-64 --docker-image foo": [call('cannot use `-a osx_x86-64` and --docker')],
+  "build zlib -a slc7_x86-64 --annotate foobar": [call("--annotate takes arguments of the form PACKAGE=COMMENT")],
   "analytics": [call(ANALYTICS_MISSING_STATE_ERROR)]
 }
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -264,6 +264,7 @@ class BuildTestCase(unittest.TestCase):
             force_rebuild=[],
             defaults="release",
             jobs=2,
+            annotate={},
             preferSystem=[],
             noSystem=False,
             debug=True,


### PR DESCRIPTION
Write some more metadata for packages (augmenting and renaming the .full-dependencies file), including a user-supplied comment string, if any.

Users can supply comments using the new `--annotate PACKAGE=COMMENT` flag.

Currently, it is not checked whether the comment is actually applied. If the package is already installed, its comment is silently ignored.