### PR TITLE
Generate init.sh in one place

### DIFF
--- a/tests/testdist/clobber-initdotsh.sh
+++ b/tests/testdist/clobber-initdotsh.sh
@@ -1,0 +1,4 @@
+package: clobber-initdotsh
+version: "1"
+---
+echo exit 1 > "$INSTALLROOT/etc/profile.d/init.sh"

--- a/tests/testdist/delete-etc.sh
+++ b/tests/testdist/delete-etc.sh
@@ -1,0 +1,4 @@
+package: delete-etc
+version: "1"
+---
+rm -rf "$INSTALLROOT/etc"

--- a/tox.ini
+++ b/tox.ini
@@ -99,6 +99,12 @@ commands =
     sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build broken6 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "while scanning a quoted scalar"'
     sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build broken7 --force-unknown-architecture --no-system --disable GCC-Toolchain 2>&1 | tee /dev/stderr | grep "Malformed entry prefer_system"'
 
+    # Make sure that etc/profile.d/init.sh is re-written properly, even if the package build overwrites it.
+    # In particular, AliEn-Runtime does this, so we must handle this.
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build clobber-initdotsh -a {env:ARCHITECTURE} --no-system --no-remote-store >&2 && WORK_DIR=$PWD/sw . sw/{env:ARCHITECTURE}/clobber-initdotsh/1-local1/etc/profile.d/init.sh'
+    # AliRoot-OCDB deletes $INSTALLROOT/etc/ during build, so make sure we can handle that fine too.
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build delete-etc -a {env:ARCHITECTURE} --no-system --no-remote-store >&2 && WORK_DIR=$PWD/sw . sw/{env:ARCHITECTURE}/delete-etc/1-local1/etc/profile.d/init.sh'
+
     coverage run --source={toxinidir} -a {toxinidir}/aliBuild build zlib -a {env:ARCHITECTURE} --no-system --disable GCC-Toolchain
     alienv -a {env:ARCHITECTURE} q
     alienv -a {env:ARCHITECTURE} setenv zlib/latest -c bash -c '[[ $LD_LIBRARY_PATH == */zlib/* ]]'


### PR DESCRIPTION
This reduces the duplication in the init.sh generation code significantly.

Instead of generating shell commands that generate init.sh, scattered all over the place, generate the contents of init.sh in one place and just write them into the file when applicable.

Once created, load the generated file instead of generating the same shell code twice at different escaping levels.

All of this reduces the potential for errors a lot, since different places in the code don't need to be kept in sync when generating and re-generating the file.

Add tests that make sure the generated file contents are vaguely sensible, and that clobbering the file during the build (as the AliEn-Runtime package does) does not mean it is mangled during subsequent builds.

This PR requires #818 for the added tox test to work, so I've included that commit here. I'll rebase once that PR is merged.