### PR TITLE
Fix crash when sourcing pre-build init.sh

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -359,7 +359,7 @@ def generate_initdotsh(package, specs, architecture, post_build=False):
   # These variables are also required during the build itself, so always
   # generate them.
   lines.extend((
-    '[ -z "${{{bigpackage}_REVISION}}" ] && '
+    '[ -n "${{{bigpackage}_REVISION}}" ] || '
     '. "$WORK_DIR/$ALIBUILD_ARCH_PREFIX"/{package}/{version}-{revision}/etc/profile.d/init.sh'
   ).format(
     bigpackage=dep.upper().replace("-", "_"),


### PR DESCRIPTION
If the last line in init.sh would load a package that was already loaded, [ -z ... ] returns false, which would mean the entire script's exit code is false, and the build would fail.

Fix this, so that the expression always returns true (either if the package is already loaded or if it is loaded by the line in question).