### PR TITLE
Avoid finding false-positive symlinks and printing warnings for them

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -32,7 +32,6 @@ except ImportError:
   from pipes import quote  # Python 2.7
 
 import concurrent.futures
-import errno
 import importlib
 import json
 import socket
@@ -802,9 +801,8 @@ def doBuild(args, parser):
                   for symlink in os.listdir(symlink_dir)
                   if links_regex.fullmatch(symlink)]
     except OSError as exc:
-      # If symlink_dir does not exist, return an empty list of packages.
-      if exc.errno != errno.ENOENT:
-        raise
+      # If symlink_dir does not exist or cannot be accessed, return an empty
+      # list of packages.
       packages = []
     del links_regex, symlink_dir
 


### PR DESCRIPTION
If users build e.g. O2Physics first with a branch called "x-y", and then later with a branch called "x", then aliBuild would print warnings about not being able to parse symlinks.

This is caused by an overly-broad glob when listing symlinks.

Replace this glob with a regex modelled after the regex that parses symlink targets, to avoid these false positives.