### PR TITLE
Install pigz by default on Ubuntu

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -9,5 +9,6 @@ X-Python3-Version: >= 3.6
 Package: python3-alibuild
 Architecture: all
 Description: ALICE build tool.
-	Please refer to https://alisw.github.io for full documentation
+	Please refer to https://alisw.github.io/alibuild for full documentation.
 Depends: ${python3:Depends},python3-requests,python3-yaml
+Recommends: pigz


### PR DESCRIPTION
Recommend the installation of pigz on Ubuntu as a dependency of alibuild. This means pigz will be installed by default, unless the user explicitly runs `apt install --no-install-recommends python3-alibuild`.