### PR TITLE
Make `aliBuild build` much more efficient

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -961,7 +961,7 @@ def build_or_unpack_package(package, specs, args):
             "provenance": create_provenance_info(spec["package"], specs, args),
             "initdotsh_deps": generate_initdotsh(package, specs, args.architecture, post_build=False),
             "initdotsh_full": generate_initdotsh(package, specs, args.architecture, post_build=True),
-            "workDir": args.workDir,
+            "workDir": os.path.abspath(args.workDir),
             "configDir": abspath(args.configDir),
             "incremental_recipe": spec.get("incremental_recipe", ":"),
             "sourceDir": (dirname(source) + "/") if source else "",

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -1102,9 +1102,12 @@ def doBuild(args, parser):
     log_current_package(None, main_package, specs, devel_prefix)
 
     # Each package needs its dependencies' hashes to be set, so iterate in build order.
-    for package in build_order:
+    progress = ProgressPrint("Looking for packages to reuse")
+    for i, package in enumerate(build_order):
+        progress("[%d/%d] Resolving hash and symlinks", i, len(build_order))
         assign_revision_number(package, specs, remote, args.workDir, args.architecture,
                                args.defaults, devel_prefix)
+    progress.end("done")
 
     # Now that we have all the information about each package we need, detect
     # any of them that have already been built and/or unpacked and skip them.

--- a/alibuild_helpers/build_template.sh
+++ b/alibuild_helpers/build_template.sh
@@ -308,10 +308,11 @@ if [ "$CAN_DELETE" = 1 ]; then
   # There might be an old existing tarball, and we should delete it.
   rm -f "$WORK_DIR/TARS/$HASH_PATH/$PACKAGE_WITH_REV"
 elif [ -z "$CACHED_TARBALL" ]; then
+  gzip=$(command -v pigz 2>/dev/null || echo gzip)
   # We don't have an existing tarball, and we want to keep the one we create now.
   tar -cC "$WORK_DIR/INSTALLROOT/$PKGHASH" . |
     # Avoid having broken left overs if the tar fails.
-    $MY_GZIP -c > "$WORK_DIR/TARS/$HASH_PATH/$PACKAGE_WITH_REV.processing"
+    $gzip -c > "$WORK_DIR/TARS/$HASH_PATH/$PACKAGE_WITH_REV.processing"
   mv "$WORK_DIR/TARS/$HASH_PATH/$PACKAGE_WITH_REV.processing" \
      "$WORK_DIR/TARS/$HASH_PATH/$PACKAGE_WITH_REV"
   ln -nfs "../../$HASH_PATH/$PACKAGE_WITH_REV" \

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -4,7 +4,7 @@ except ImportError:
   from pipes import quote  # Python 2.7
 from alibuild_helpers.cmd import getstatusoutput
 from alibuild_helpers.log import debug
-from alibuild_helpers.scm import SCM
+from alibuild_helpers.scm import SCM, SCMError
 
 GIT_COMMAND_TIMEOUT_SEC = 120
 """How many seconds to let any git command execute before being terminated."""
@@ -65,5 +65,5 @@ def git(args, directory=".", check=True, prompt=True):
     prompt_var="GIT_TERMINAL_PROMPT=0" if not prompt else "",
   ), timeout=GIT_COMMAND_TIMEOUT_SEC)
   if check and err != 0:
-    raise RuntimeError("Error {} from git {}: {}".format(err, " ".join(args), output))
+    raise SCMError("Error {} from git {}: {}".format(err, " ".join(args), output))
   return output if check else (err, output)

--- a/alibuild_helpers/scm.py
+++ b/alibuild_helpers/scm.py
@@ -1,3 +1,7 @@
+class SCMError(Exception):
+  """Signal that a source-control-related operation failed."""
+
+
 class SCM(object):
   def checkedOutCommitName(self, directory):
     raise NotImplementedError

--- a/alibuild_helpers/sl.py
+++ b/alibuild_helpers/sl.py
@@ -1,7 +1,7 @@
 from shlex import quote  # Python 3.3+
 from alibuild_helpers.cmd import getstatusoutput
 from alibuild_helpers.log import debug
-from alibuild_helpers.scm import SCM
+from alibuild_helpers.scm import SCM, SCMError
 
 SL_COMMAND_TIMEOUT_SEC = 120
 """How many seconds to let any sl command execute before being terminated."""
@@ -49,5 +49,5 @@ def sapling(args, directory=".", check=True, prompt=True):
     args=" ".join(map(quote, args)),
   ), timeout=SL_COMMAND_TIMEOUT_SEC)
   if check and err != 0:
-    raise RuntimeError("Error {} from sl {}: {}".format(err, " ".join(args), output))
+    raise SCMError("Error {} from sl {}: {}".format(err, " ".join(args), output))
   return output if check else (err, output)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -1,7 +1,0 @@
-import unittest
-from alibuild_helpers.utilities import check_coverage
-
-class FooTest(unittest.TestCase):
-    def test_foo(self):
-        self.assertTrue(check_coverage())
-

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 from alibuild_helpers.git import git
+from alibuild_helpers.scm import SCMError
 
 EXISTING_REPO = "https://github.com/alisw/alibuild"
 MISSING_REPO = "https://github.com/alisw/nonexistent"
@@ -36,12 +37,12 @@ class GitWrapperTestCase(unittest.TestCase):
 
     def test_git_missing_repo(self):
         """Check we get the right exception when a repo doesn't exist."""
-        self.assertRaises(RuntimeError, git, (
+        self.assertRaises(SCMError, git, (
             "ls-remote", "-ht", MISSING_REPO,
         ), prompt=False)
 
     def test_git_private_repo(self):
         """Check we get the right exception when credentials are required."""
-        self.assertRaises(RuntimeError, git, (
+        self.assertRaises(SCMError, git, (
             "-c", "credential.helper=", "ls-remote", "-ht", PRIVATE_REPO,
         ), prompt=False)

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     from ordereddict import OrderedDict
 
-from alibuild_helpers.build import storeHashes
+from alibuild_helpers.build import store_hashes
 
 LOGFILE = "build.log"
 SPEC_RE = re.compile(r"spec = (OrderedDict\(\[\('package', '([^']+)'.*\)\]\))")
@@ -18,7 +18,7 @@ HASH_RE = re.compile(r"Hashes for recipe (.*) are "
 
 
 class KnownGoodHashesTestCase(unittest.TestCase):
-    """Make sure storeHashes produces the same hashes as in a build log.
+    """Make sure store_hashes produces the same hashes as in a build log.
 
     It is assumed that the hashes in the build log are correct, i.e. the ones
     we want to get for the matching spec in the log.
@@ -49,11 +49,10 @@ class KnownGoodHashesTestCase(unittest.TestCase):
                     # Once a package is built, it will have a second "spec ="
                     # and "Hashes for recipe" line in the log. In that case, we
                     # don't want to check the hashes are correct, as
-                    # storeHashes doesn't do anything in that case (the spec
+                    # store_hashes doesn't do anything in that case (the spec
                     # from the log will already have hashes stored).
                     continue
-                storeHashes(package, specs,
-                            isDevelPkg=False, considerRelocation=False)
+                store_hashes(package, specs, consider_relocation=False)
                 spec = specs[package]
                 self.assertEqual(spec["remote_revision_hash"], remote)
                 self.assertEqual(spec["local_revision_hash"], local)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -21,7 +21,8 @@ class LogTestCase(unittest.TestCase):
         mock_error.assert_not_called()
         mock_sys.exit.assert_not_called()
 
-    @patch("alibuild_helpers.log.sys.stderr", new=MagicMock(return_value=True))
+    @patch("sys.stdout.isatty", new=MagicMock(return_value=True))
+    @patch("sys.stderr", new=MagicMock(return_value=True))
     def test_ProgressPrint(self):
         """Make sure ProgressPrint updates correctly."""
         # ProgressPrint only parses messages every 0.5s. Trick it into thinking

--- a/tox.ini
+++ b/tox.ini
@@ -101,9 +101,9 @@ commands =
 
     # Make sure that etc/profile.d/init.sh is re-written properly, even if the package build overwrites it.
     # In particular, AliEn-Runtime does this, so we must handle this.
-    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build clobber-initdotsh -a {env:ARCHITECTURE} --no-system --no-remote-store >&2 && WORK_DIR=$PWD/sw . sw/{env:ARCHITECTURE}/clobber-initdotsh/1-local1/etc/profile.d/init.sh'
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist --debug build clobber-initdotsh -a {env:ARCHITECTURE} --no-system --no-remote-store >&2 && WORK_DIR=$PWD/sw . sw/{env:ARCHITECTURE}/clobber-initdotsh/1-local1/etc/profile.d/init.sh'
     # AliRoot-OCDB deletes $INSTALLROOT/etc/ during build, so make sure we can handle that fine too.
-    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist build delete-etc -a {env:ARCHITECTURE} --no-system --no-remote-store >&2 && WORK_DIR=$PWD/sw . sw/{env:ARCHITECTURE}/delete-etc/1-local1/etc/profile.d/init.sh'
+    sh -c 'coverage run --source={toxinidir} -a {toxinidir}/aliBuild -c {toxinidir}/tests/testdist --debug build delete-etc -a {env:ARCHITECTURE} --no-system --no-remote-store >&2 && WORK_DIR=$PWD/sw . sw/{env:ARCHITECTURE}/delete-etc/1-local1/etc/profile.d/init.sh'
 
     coverage run --source={toxinidir} -a {toxinidir}/aliBuild build zlib -a {env:ARCHITECTURE} --no-system --disable GCC-Toolchain
     alienv -a {env:ARCHITECTURE} q


### PR DESCRIPTION
* Only fetch git repos for packages that we'll actually compile. If we download a tarball, we don't need the repo. This saves downloading e.g. the massive Clang repo.

* If a package is already installed, don't (re-)fetch a tarball for it. This stops us from constantly redownloading useless tarballs after `aliBuild clean --aggressive-cleanup`.

* Make it more obvious to the user what is happening, specifically whether a package is being compiled or downloaded and unpacked. Show git-clone and download progress. In general, prefer showing progress percentages instead of showing lots of output in non-debug mode.

* Do as much work as possible before we start to compile the first package, so that (a) more info is available to plugins, and (b) we can print more helpful messages. Drop the weird control flow where we'd try to build everything twice, just to detect that the package was already built on the second try. This makes log messages much less confusing.

* Update tests to match.