### PR TITLE
Save more data in `sw/MIRROR` using `--filter=tree:0`

### DIFF
--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -1,7 +1,4 @@
-try:
-  from shlex import quote  # Python 3.3+
-except ImportError:
-  from pipes import quote  # Python 2.7
+from shlex import quote
 from alibuild_helpers.cmd import getstatusoutput
 from alibuild_helpers.log import debug
 from alibuild_helpers.scm import SCM, SCMError
@@ -12,10 +9,12 @@ GIT_COMMAND_TIMEOUT_SEC = 120
 
 def clone_speedup_options():
   """Return a list of options supported by the system git which speed up cloning."""
-  _, out = getstatusoutput("LANG=C git clone --filter=blob:none")
-  if "unknown option" not in out and "invalid filter-spec" not in out:
-    return ["--filter=blob:none"]
+  for filter_option in ("--filter=tree:0", "--filter=blob:none"):
+    _, out = getstatusoutput("LANG=C git clone " + filter_option)
+    if "unknown option" not in out and "invalid filter-spec" not in out:
+      return [filter_option]
   return []
+
 
 class Git(SCM):
   name = "Git"

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -9,7 +9,6 @@ except ImportError:
   from ordereddict import OrderedDict
 
 from alibuild_helpers.log import dieOnError, debug, info, error
-from alibuild_helpers.git import clone_speedup_options
 
 FETCH_LOG_NAME = "fetch-log.txt"
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -184,7 +184,7 @@ def dummy_exists(x):
 # A few errors we should handle, together with the expected result
 @patch("alibuild_helpers.build.clone_speedup_options",
        new=MagicMock(return_value=["--filter=blob:none"]))
-@patch("alibuild_helpers.workarea.clone_speedup_options",
+@patch("alibuild_helpers.git.clone_speedup_options",
        new=MagicMock(return_value=["--filter=blob:none"]))
 @patch("alibuild_helpers.build.BASH", new="/bin/bash")
 class BuildTestCase(unittest.TestCase):

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -22,7 +22,7 @@ MOCK_SPEC = OrderedDict((
 
 @patch("alibuild_helpers.workarea.debug", new=MagicMock())
 @patch("alibuild_helpers.workarea.info", new=MagicMock())
-@patch("alibuild_helpers.workarea.clone_speedup_options",
+@patch("alibuild_helpers.git.clone_speedup_options",
        new=MagicMock(return_value=["--filter=blob:none"]))
 class WorkareaTestCase(unittest.TestCase):
 


### PR DESCRIPTION
If git supports it, prefer the `--filter=tree:0` option to `--filter=blob:none`, but fall back to the latter if the former is not supported.

If using a Docker container, use neither (as before), since we don't know whether the git in the container can read the repo we produce outside the container.