### PR TITLE
UI improvements and tarballs fix

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -851,11 +851,13 @@ def doBuild(args, parser):
       else:
         debug("Package %s with hash %s is already found in %s. Not building.",
               p, rev_hash, symlink_path)
-        symlink("{version}-{revision}".format(**spec),
-                "{wd}/{arch}/{package}/latest-{build_family}".format(wd=workDir, arch=args.architecture, **spec))
-        symlink("{version}-{revision}".format(**spec),
-                "{wd}/{arch}/{package}/latest".format(wd=workDir, arch=args.architecture, **spec))
-        info("Using cached build for %s", p)
+        # Ignore errors here, because the path we're linking to might not
+        # exist (if this is the first run through the loop). On the second run
+        # through, the path should have been created by the build process.
+        call_ignoring_oserrors(symlink, "{version}-{revision}".format(**spec),
+                               "{wd}/{arch}/{package}/latest-{build_family}".format(wd=workDir, arch=args.architecture, **spec))
+        call_ignoring_oserrors(symlink, "{version}-{revision}".format(**spec),
+                               "{wd}/{arch}/{package}/latest".format(wd=workDir, arch=args.architecture, **spec))
 
     # Now we know whether we're using a local or remote package, so we can set
     # the proper hash and tarball directory.
@@ -869,6 +871,9 @@ def doBuild(args, parser):
     # Recreate symlinks to this development package builds.
     if spec["package"] in develPkgs:
       debug("Creating symlinks to builds of devel package %s", spec["package"])
+      # Ignore errors here, because the path we're linking to might not exist
+      # (if this is the first run through the loop). On the second run
+      # through, the path should have been created by the build process.
       call_ignoring_oserrors(symlink, spec["hash"], join(workDir, "BUILD", spec["package"] + "-latest"))
       if develPrefix:
         call_ignoring_oserrors(symlink, spec["hash"], join(workDir, "BUILD", spec["package"] + "-latest-" + develPrefix))

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -749,7 +749,7 @@ def doBuild(args, parser):
     # this will result in a new package which has the same binary contents of
     # the old one but where the relocation will work for the new dictory. Here
     # we simply store the fact that we can reuse the contents of cachedTarball.
-    syncHelper.syncToLocal(p, spec)
+    syncHelper.fetch_symlinks(spec)
 
     # Decide how it should be called, based on the hash and what is already
     # available.
@@ -961,11 +961,9 @@ def doBuild(args, parser):
 
     tar_hash_dir = os.path.join(workDir, resolve_store_path(args.architecture, spec["hash"]))
     debug("Looking for cached tarball in %s", tar_hash_dir)
-    # FIXME: I should get the tar_hash_dir updated with server at this point.
-    #        It does not really matter that the symlinks are ok at this point
-    #        as I only used the tarballs as reusable binary blobs.
     spec["cachedTarball"] = ""
     if not spec["is_devel_pkg"]:
+      syncHelper.fetch_tarball(spec)
       tarballs = glob(os.path.join(tar_hash_dir, "*gz"))
       spec["cachedTarball"] = tarballs[0] if len(tarballs) else ""
       debug("Found tarball in %s" % spec["cachedTarball"]
@@ -1141,7 +1139,7 @@ def doBuild(args, parser):
     # Make sure not to upload local-only packages! These might have been
     # produced in a previous run with a read-only remote store.
     if not spec["revision"].startswith("local"):
-      syncHelper.syncToRemote(p, spec)
+      syncHelper.upload_symlinks_and_tarball(spec)
 
   banner("Build of %s successfully completed on `%s'.\n"
          "Your software installation is at:"

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -1087,10 +1087,12 @@ def doBuild(args, parser):
       build_command = "%s -e -x %s/build.sh 2>&1" % (BASH, quote(scriptDir))
 
     debug("Build command: %s", build_command)
-    progress = ProgressPrint("%s %s@%s (use --debug for full output)" % (
-        "Unpacking tarball for" if cachedTarball else "Compiling", spec["package"],
-        args.develPrefix if "develPrefix" in args and spec["is_devel_pkg"] else spec["version"],
-    ))
+    progress = ProgressPrint(
+      ("Unpacking %s@%s" if cachedTarball else
+       "Compiling %s@%s (use --debug for full output)") %
+      (spec["package"],
+       args.develPrefix if "develPrefix" in args and spec["is_devel_pkg"] else spec["version"])
+    )
     err = execute(build_command, printer=progress)
     progress.end("failed" if err else "done", err)
     report_event("BuildError" if err else "BuildSuccess", spec["package"], " ".join((

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
   from ordereddict import OrderedDict
 
-from alibuild_helpers.log import dieOnError, debug, info, error
+from alibuild_helpers.log import dieOnError, debug, error
 
 FETCH_LOG_NAME = "fetch-log.txt"
 
@@ -37,8 +37,7 @@ def logged_scm(scm, package, referenceSources,
   must not contain any secrets. We only output the SCM command we ran, its exit
   code, and the package name, so this should be safe.
   """
-  # This might take a long time, so show the user what's going on.
-  info("%s %s for repository for %s...", scm.name, command[0], package)
+  debug("%s %s for repository for %s...", scm.name, command[0], package)
   err, output = scm.exec(command, directory=directory, check=False, prompt=prompt)
   if logOutput:
     debug(output)
@@ -53,7 +52,7 @@ def logged_scm(scm, package, referenceSources,
       error("Could not write error log from SCM command:", exc_info=exc)
   dieOnError(err, "Error during %s %s for reference repo for %s." %
              (scm.name.lower(), command[0], package))
-  info("Done %s %s for repository for %s", scm.name.lower(), command[0], package)
+  debug("Done %s %s for repository for %s", scm.name.lower(), command[0], package)
   return output
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -334,18 +334,20 @@ class BuildTestCase(unittest.TestCase):
             except KeyError:
                 spec["commit_hash"] = spec["scm_refs"]["refs/heads/" + spec["tag"]]
         specs = {pkg["package"]: pkg for pkg in (default, zlib, root, extra)}
+        for spec in specs.values():
+            spec["is_devel_pkg"] = False
 
-        storeHashes("defaults-release", specs, isDevelPkg=False, considerRelocation=False)
+        storeHashes("defaults-release", specs, considerRelocation=False)
         default["hash"] = default["remote_revision_hash"]
         self.assertEqual(default["hash"], TEST_DEFAULT_RELEASE_BUILD_HASH)
         self.assertEqual(default["remote_hashes"], [TEST_DEFAULT_RELEASE_BUILD_HASH])
 
-        storeHashes("zlib", specs, isDevelPkg=False, considerRelocation=False)
+        storeHashes("zlib", specs, considerRelocation=False)
         zlib["hash"] = zlib["local_revision_hash"]
         self.assertEqual(zlib["hash"], TEST_ZLIB_BUILD_HASH)
         self.assertEqual(zlib["local_hashes"], [TEST_ZLIB_BUILD_HASH])
 
-        storeHashes("ROOT", specs, isDevelPkg=False, considerRelocation=False)
+        storeHashes("ROOT", specs, considerRelocation=False)
         root["hash"] = root["local_revision_hash"]
         self.assertEqual(root["hash"], TEST_ROOT_BUILD_HASH)
         # Equivalent "commit hashes": "f7b336611753f1f4aaa94222b0d620748ae230c0"
@@ -353,7 +355,7 @@ class BuildTestCase(unittest.TestCase):
         self.assertEqual(len(root["local_hashes"]), 2)
         self.assertEqual(root["local_hashes"][0], TEST_ROOT_BUILD_HASH)
 
-        storeHashes("Extra", specs, isDevelPkg=False, considerRelocation=False)
+        storeHashes("Extra", specs, considerRelocation=False)
         extra["hash"] = extra["local_revision_hash"]
         self.assertEqual(extra["hash"], TEST_EXTRA_BUILD_HASH)
         # Equivalent "commit hashes": "v1", "v2", "ba22".

--- a/tests/test_hashing.py
+++ b/tests/test_hashing.py
@@ -40,6 +40,7 @@ class KnownGoodHashesTestCase(unittest.TestCase):
                 if match:
                     spec_expr, package = match.groups()
                     specs[package] = eval(spec_expr, {"OrderedDict": OrderedDict})
+                    specs[package]["is_devel_pkg"] = False
                     continue
                 match = re.search(HASH_RE, line)
                 if not match:
@@ -52,8 +53,7 @@ class KnownGoodHashesTestCase(unittest.TestCase):
                     # storeHashes doesn't do anything in that case (the spec
                     # from the log will already have hashes stored).
                     continue
-                storeHashes(package, specs,
-                            isDevelPkg=False, considerRelocation=False)
+                storeHashes(package, specs, considerRelocation=False)
                 spec = specs[package]
                 self.assertEqual(spec["remote_revision_hash"], remote)
                 self.assertEqual(spec["local_revision_hash"], local)

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -68,6 +68,7 @@ class MockRequest:
                 self._bytes_left -= toread
 
 
+@patch("alibuild_helpers.sync.ProgressPrint", new=MagicMock())
 class SyncTestCase(unittest.TestCase):
     def mock_get(self, url, *args, **kw):
         if NONEXISTENT_HASH in url:
@@ -174,6 +175,7 @@ class SyncTestCase(unittest.TestCase):
 @unittest.skipIf(sys.version_info < (3, 6), "python >= 3.6 is required for boto3")
 @patch("os.makedirs", new=MagicMock(return_value=None))
 @patch("alibuild_helpers.sync.symlink", new=MagicMock(return_value=None))
+@patch("alibuild_helpers.sync.ProgressPrint", new=MagicMock())
 @patch("alibuild_helpers.log.error", new=MagicMock())
 @patch("alibuild_helpers.sync.Boto3RemoteSync._s3_init", new=MagicMock())
 class Boto3TestCase(unittest.TestCase):
@@ -232,8 +234,9 @@ class Boto3TestCase(unittest.TestCase):
             if NONEXISTENT_HASH in Key or BAD_HASH in Key or \
                os.path.basename(Key) == tarball_name(MISSING_SPEC):
                 raise ClientError({"Error": {"Code": "404"}}, "head_object")
+            return {}
 
-        def download_file(Bucket, Key, Filename):
+        def download_file(Bucket, Key, Filename, Callback=None):
             self.assertNotIn(NONEXISTENT_HASH, Key, "tried to fetch missing tarball")
             self.assertNotIn(BAD_HASH, Key, "tried to follow bad symlink")
 

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -89,6 +89,7 @@ class SyncTestCase(unittest.TestCase):
     @patch("os.path.isfile", new=MagicMock(return_value=False))
     @patch("os.rename", new=MagicMock(return_value=None))
     @patch("os.makedirs", new=MagicMock(return_value=None))
+    @patch("os.listdir", new=MagicMock(return_value=[]))
     @patch("alibuild_helpers.sync.symlink", new=MagicMock(return_value=None))
     @patch("alibuild_helpers.sync.execute", new=MagicMock(return_value=None))
     @patch("alibuild_helpers.sync.debug")
@@ -105,14 +106,16 @@ class SyncTestCase(unittest.TestCase):
         # Try good spec
         mock_error.reset_mock()
 
-        syncer.syncToLocal(PACKAGE, GOOD_SPEC)
+        syncer.fetch_symlinks(GOOD_SPEC)
+        syncer.fetch_tarball(GOOD_SPEC)
         mock_error.assert_not_called()
-        syncer.syncToRemote(PACKAGE, GOOD_SPEC)
+        syncer.upload_symlinks_and_tarball(GOOD_SPEC)
 
         # Try bad spec
         mock_error.reset_mock()
 
-        syncer.syncToLocal(PACKAGE, BAD_SPEC)
+        syncer.fetch_symlinks(BAD_SPEC)
+        syncer.fetch_tarball(BAD_SPEC)
 
         # We can't use mock_error.assert_called_once_with because two
         # PartialDownloadError instances don't compare equal.
@@ -127,13 +130,14 @@ class SyncTestCase(unittest.TestCase):
         self.assertIsInstance(mock_error.call_args_list[0][0][2],
                               sync.PartialDownloadError)
 
-        syncer.syncToRemote(PACKAGE, BAD_SPEC)
+        syncer.upload_symlinks_and_tarball(BAD_SPEC)
 
         # Try missing spec
         mock_debug.reset_mock()
-        syncer.syncToLocal(PACKAGE, MISSING_SPEC)
+        syncer.fetch_symlinks(MISSING_SPEC)
+        syncer.fetch_tarball(MISSING_SPEC)
         mock_debug.assert_called_with("Nothing fetched for %s (%s)",
-                                      PACKAGE, NONEXISTENT_HASH)
+                                      MISSING_SPEC["package"], NONEXISTENT_HASH)
 
     @patch("alibuild_helpers.sync.execute", new=lambda cmd, printer=None: 0)
     @patch("alibuild_helpers.sync.os")
@@ -158,11 +162,13 @@ class SyncTestCase(unittest.TestCase):
 
         for spec in (GOOD_SPEC, BAD_SPEC):
             for syncer in syncers:
-                syncer.syncToLocal(PACKAGE, spec)
-                syncer.syncToRemote(PACKAGE, spec)
+                syncer.fetch_symlinks(spec)
+                syncer.fetch_tarball(spec)
+                syncer.upload_symlinks_and_tarball(spec)
 
         for syncer in syncers:
-            syncer.syncToLocal(PACKAGE, MISSING_SPEC)
+            syncer.fetch_symlinks(MISSING_SPEC)
+            syncer.fetch_tarball(MISSING_SPEC)
 
 
 @unittest.skipIf(sys.version_info < (3, 6), "python >= 3.6 is required for boto3")
@@ -268,15 +274,18 @@ class Boto3TestCase(unittest.TestCase):
         b3sync.s3 = self.mock_s3()
 
         b3sync.s3.download_file.reset_mock()
-        b3sync.syncToLocal(PACKAGE, GOOD_SPEC)
+        b3sync.fetch_symlinks(GOOD_SPEC)
+        b3sync.fetch_tarball(GOOD_SPEC)
         b3sync.s3.download_file.assert_called()
 
         b3sync.s3.download_file.reset_mock()
-        b3sync.syncToLocal(PACKAGE, BAD_SPEC)
+        b3sync.fetch_symlinks(BAD_SPEC)
+        b3sync.fetch_tarball(BAD_SPEC)
         b3sync.s3.download_file.assert_not_called()
 
         b3sync.s3.download_file.reset_mock()
-        b3sync.syncToLocal(PACKAGE, MISSING_SPEC)
+        b3sync.fetch_symlinks(MISSING_SPEC)
+        b3sync.fetch_tarball(MISSING_SPEC)
         b3sync.s3.download_file.assert_not_called()
 
     @patch("os.listdir", new=lambda path: (
@@ -297,7 +306,7 @@ class Boto3TestCase(unittest.TestCase):
         # Make sure upload of a fresh, new tarball works fine.
         b3sync.s3.put_object.reset_mock()
         b3sync.s3.upload_file.reset_mock()
-        b3sync.syncToRemote(PACKAGE, MISSING_SPEC)
+        b3sync.upload_symlinks_and_tarball(MISSING_SPEC)
         # We simulated local builds, so we should upload the tarballs to
         # the remote.
         b3sync.s3.put_object.assert_called()
@@ -305,7 +314,7 @@ class Boto3TestCase(unittest.TestCase):
 
         b3sync.s3.put_object.reset_mock()
         b3sync.s3.upload_file.reset_mock()
-        b3sync.syncToRemote(PACKAGE, GOOD_SPEC)
+        b3sync.upload_symlinks_and_tarball(GOOD_SPEC)
         # We simulated downloading tarballs from the remote, so we mustn't
         # upload them again and overwrite the remote.
         b3sync.s3.put_object.assert_not_called()
@@ -314,7 +323,7 @@ class Boto3TestCase(unittest.TestCase):
         # Make sure conflict detection is working for tarball sync.
         b3sync.s3.put_object.reset_mock()
         b3sync.s3.upload_file.reset_mock()
-        self.assertRaises(SystemExit, b3sync.syncToRemote, PACKAGE, BAD_SPEC)
+        self.assertRaises(SystemExit, b3sync.upload_symlinks_and_tarball, BAD_SPEC)
         b3sync.s3.put_object.assert_not_called()
         b3sync.s3.upload_file.assert_not_called()
 

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -21,7 +21,6 @@ MOCK_SPEC = OrderedDict((
 
 
 @patch("alibuild_helpers.workarea.debug", new=MagicMock())
-@patch("alibuild_helpers.workarea.info", new=MagicMock())
 @patch("alibuild_helpers.git.clone_speedup_options",
        new=MagicMock(return_value=["--filter=blob:none"]))
 class WorkareaTestCase(unittest.TestCase):


### PR DESCRIPTION
See individual commits.

* Only download tarballs if we're going to use them (fixes https://its.cern.ch/jira/browse/O2-3882)
* Show download progress interactively (if possible) using `ProgressPrint`
* Show progress of cloning "mirror" repositories, replacing "spammy" per-repo output with one `ProgressPrint` (in non-debug mode)

Also contains one cleanup/refactoring commit (https://github.com/alisw/alibuild/commit/4236ab3044778141605f6e493ad275c46963daf5) -- let me know if you want a separate PR for that one.