### PR TITLE
Clone SOURCES repos outside container

### DIFF
--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -32,8 +32,8 @@ class Git(SCM):
       git_ref: git_hash for git_hash, sep, git_ref
       in (line.partition("\t") for line in output.splitlines()) if sep
     }
-  def listRefsCmd(self):
-    return ["ls-remote", "--heads", "--tags"]
+  def listRefsCmd(self, repository):
+    return ["ls-remote", "--heads", "--tags", repository]
   def cloneCmd(self, source, referenceRepo, usePartialClone):
     cmd = ["clone", "--bare", source, referenceRepo]
     if usePartialClone:

--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -66,6 +66,7 @@ def doInit(args):
 
   for p in pkgs:
     spec = specs.get(p["name"])
+    spec["is_devel_pkg"] = False
     spec["scm"] = Git()
     dieOnError(spec is None, "cannot find recipe for package %s" % p["name"])
     dest = join(args.develPrefix, spec["package"])

--- a/alibuild_helpers/scm.py
+++ b/alibuild_helpers/scm.py
@@ -15,7 +15,15 @@ class SCM(object):
     raise NotImplementedError
   def exec(self, *args, **kwargs):
     raise NotImplementedError
-  def cloneCmd(self, spec, referenceRepo, usePartialClone):
+  def checkoutCmd(self, tag):
+    raise NotImplementedError
+  def fetchCmd(self, remote, *refs):
+    raise NotImplementedError
+  def cloneReferenceCmd(self, spec, referenceRepo, usePartialClone):
+    raise NotImplementedError
+  def cloneSourceCmd(self, spec, referenceRepo, usePartialClone):
+    raise NotImplementedError
+  def setWriteUrlCmd(self, url):
     raise NotImplementedError
   def diffCmd(self, directory):
     raise NotImplementedError

--- a/alibuild_helpers/scm.py
+++ b/alibuild_helpers/scm.py
@@ -9,7 +9,7 @@ class SCM(object):
     raise NotImplementedError
   def lsRemote(self, remote):
     raise NotImplementedError
-  def listRefsCmd(self):
+  def listRefsCmd(self, repository):
     raise NotImplementedError
   def parseRefs(self, output):
     raise NotImplementedError

--- a/alibuild_helpers/sl.py
+++ b/alibuild_helpers/sl.py
@@ -6,6 +6,7 @@ from alibuild_helpers.scm import SCM, SCMError
 SL_COMMAND_TIMEOUT_SEC = 120
 """How many seconds to let any sl command execute before being terminated."""
 
+
 # Sapling is a novel SCM by Meta (i.e. Facebook) that is fully compatible with
 # git, but has a different command line interface. Among the reasons why it's
 # worth suporting it is the ability to handle unnamed branches, the ability to
@@ -14,25 +15,33 @@ SL_COMMAND_TIMEOUT_SEC = 120
 # command line from each commit of a branch.
 class Sapling(SCM):
   name = "Sapling"
+
   def checkedOutCommitName(self, directory):
     return sapling(("whereami", ), directory)
+
   def branchOrRef(self, directory):
     # Format is <hash>[+] <branch>
     identity = sapling(("identify", ), directory)
     return identity.split(" ")[-1]
+
   def exec(self, *args, **kwargs):
     return sapling(*args, **kwargs)
+
   def parseRefs(self, output):
     return {
       sl_ref: sl_hash for sl_ref, sep, sl_hash
       in (line.partition("\t") for line in output.splitlines()) if sep
     }
+
   def listRefsCmd(self, repository):
     return ["bookmark", "--list", "--remote", "-R", repository]
+
   def diffCmd(self, directory):
     return "cd %s && sl diff && sl status" % directory
+
   def checkUntracked(self, line):
     return line.startswith("? ")
+
 
 def sapling(args, directory=".", check=True, prompt=True):
   debug("Executing sl %s (in directory %s)", " ".join(args), directory)

--- a/alibuild_helpers/sl.py
+++ b/alibuild_helpers/sl.py
@@ -27,8 +27,8 @@ class Sapling(SCM):
       sl_ref: sl_hash for sl_ref, sep, sl_hash
       in (line.partition("\t") for line in output.splitlines()) if sep
     }
-  def listRefsCmd(self):
-    return ["bookmark", "--list", "--remote", "-R"]
+  def listRefsCmd(self, repository):
+    return ["bookmark", "--list", "--remote", "-R", repository]
   def diffCmd(self, directory):
     return "cd %s && sl diff && sl status" % directory
   def checkUntracked(self, line):

--- a/alibuild_helpers/workarea.py
+++ b/alibuild_helpers/workarea.py
@@ -9,6 +9,7 @@ except ImportError:
   from ordereddict import OrderedDict
 
 from alibuild_helpers.log import dieOnError, debug, error
+from alibuild_helpers.utilities import call_ignoring_oserrors
 
 FETCH_LOG_NAME = "fetch-log.txt"
 
@@ -92,18 +93,15 @@ def updateReferenceRepo(referenceSources, p, spec,
   @fetch            : whether to fetch updates: if False, only clone if not found
   """
   assert isinstance(spec, OrderedDict)
-  if "source" not in spec:
-    return
+  if spec["is_devel_pkg"] or "source" not in spec:
+    return None
 
   scm = spec["scm"]
 
   debug("Updating references.")
   referenceRepo = os.path.join(os.path.abspath(referenceSources), p.lower())
 
-  try:
-    os.makedirs(os.path.abspath(referenceSources))
-  except:
-    pass
+  call_ignoring_oserrors(os.makedirs, os.path.abspath(referenceSources), exist_ok=True)
 
   if not is_writeable(referenceSources):
     if os.path.exists(referenceRepo):

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -17,6 +17,7 @@ MOCK_SPEC = OrderedDict((
     ("package", "AliRoot"),
     ("source", "https://github.com/alisw/AliRoot"),
     ("scm", Git()),
+    ("is_devel_pkg", False),
 ))
 
 
@@ -39,7 +40,7 @@ class WorkareaTestCase(unittest.TestCase):
         updateReferenceRepoSpec(referenceSources="sw/MIRROR", p="AliRoot",
                                 spec=spec, fetch=True)
         mock_exists.assert_called_with("%s/sw/MIRROR/aliroot" % getcwd())
-        mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd())
+        mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd(), exist_ok=True)
         mock_git.assert_not_called()
         self.assertEqual(spec.get("reference"), "%s/sw/MIRROR/aliroot" % getcwd())
 
@@ -60,7 +61,7 @@ class WorkareaTestCase(unittest.TestCase):
                                 spec=spec, fetch=True)
         mock_exists.assert_called_with("%s/sw/MIRROR/aliroot" % getcwd())
         mock_exists.assert_has_calls([])
-        mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd())
+        mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd(), exist_ok=True)
         mock_git.assert_called_once_with([
             "fetch", "-f", "--tags", spec["source"], "+refs/heads/*:refs/heads/*",
         ], directory="%s/sw/MIRROR/aliroot" % getcwd(), check=False, prompt=True)
@@ -77,7 +78,7 @@ class WorkareaTestCase(unittest.TestCase):
         updateReferenceRepoSpec(referenceSources="sw/MIRROR", p="AliRoot",
                                 spec=spec, fetch=True)
         mock_exists.assert_called_with("%s/sw/MIRROR/aliroot" % getcwd())
-        mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd())
+        mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd(), exist_ok=True)
         mock_git.assert_not_called()
         self.assertNotIn("reference", spec,
                          "should delete spec['reference'], as no mirror exists")
@@ -94,7 +95,7 @@ class WorkareaTestCase(unittest.TestCase):
         updateReferenceRepoSpec(referenceSources="sw/MIRROR", p="AliRoot",
                                 spec=spec, fetch=True)
         mock_exists.assert_called_with("%s/sw/MIRROR/aliroot" % getcwd())
-        mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd())
+        mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd(), exist_ok=True)
         mock_git.assert_called_once_with([
             "clone", "--bare", spec["source"],
             "%s/sw/MIRROR/aliroot" % getcwd(), "--filter=blob:none",

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -63,7 +63,7 @@ class WorkareaTestCase(unittest.TestCase):
         mock_exists.assert_has_calls([])
         mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd(), exist_ok=True)
         mock_git.assert_called_once_with([
-            "fetch", "-f", "--tags", spec["source"], "+refs/heads/*:refs/heads/*",
+            "fetch", "-f", spec["source"], "+refs/tags/*:refs/tags/*", "+refs/heads/*:refs/heads/*",
         ], directory="%s/sw/MIRROR/aliroot" % getcwd(), check=False, prompt=True)
         self.assertEqual(spec.get("reference"), "%s/sw/MIRROR/aliroot" % getcwd())
 


### PR DESCRIPTION
This lets us always use speed-up options like `--filter`, even when we're building inside a container.

We can also easily start using sapling for this in future by implementing the new SCM methods.

This also helps with some annoying authentication-related issues, if running inside `--docker`, such as in CI.

Fixes <https://its.cern.ch/jira/browse/O2-2439>.

When this is merged, we can also get rid of the `GIT_*` environment variables used in CI, and stop installing an especially-new Git version in our containers (since that was needed to understand the `GIT_*` variables).

This PR is based on https://github.com/alisw/alibuild/pull/834; once that is merged, I can rebase to get rid of the common commits.