### PR TITLE
Do not initiate automatic gc while buiding

### DIFF
--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -92,7 +92,7 @@ def git(args, directory=".", check=True, prompt=True):
     args=" ".join(map(quote, args)),
     # GIT_TERMINAL_PROMPT is only supported in git 2.3+.
     prompt_var=f"GIT_TERMINAL_PROMPT=0" if not prompt else "",
-    directory_safe_var=f"GIT_CONFIG_COUNT={lastGitOverride+1} GIT_CONFIG_KEY_{lastGitOverride}=safe.directory GIT_CONFIG_VALUE_{lastGitOverride}=$PWD" if directory else "",
+    directory_safe_var=f"GIT_CONFIG_COUNT={lastGitOverride+2} GIT_CONFIG_KEY_{lastGitOverride}=safe.directory GIT_CONFIG_VALUE_{lastGitOverride}=$PWD GIT_CONFIG_KEY_{lastGitOverride+1}=gc.auto GIT_CONFIG_VALUE_{lastGitOverride+1}=0" if directory else "",
   ), timeout=GIT_COMMAND_TIMEOUT_SEC)
   if check and err != 0:
     raise SCMError("Error {} from git {}: {}".format(err, " ".join(args), output))


### PR DESCRIPTION
Do not initiate automatic gc while buiding

This can take quite long for some repositories (most notably Clang) and
it's clearly not something users should care about in general.
