### PR TITLE
Include clone_speedup_options in git fetch

### DIFF
--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -8,13 +8,8 @@ GIT_COMMAND_TIMEOUT_SEC = 120
 """How many seconds to let any git command execute before being terminated."""
 
 
-# Don't recalculate this every time we need it.
-_clone_speedup_cache = None
 def clone_speedup_options():
   """Return a list of options supported by the system git which speed up cloning."""
-  if _clone_speedup_cache is not None:
-    return _clone_speedup_cache
-
   for filter_option in ("--filter=tree:0", "--filter=blob:none"):
     _, out = getstatusoutput("LANG=C git clone " + filter_option)
     if "unknown option" not in out and "invalid filter-spec" not in out:

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -63,7 +63,7 @@ class Git(SCM):
     return ["checkout", "-f", ref]
 
   def fetchCmd(self, source, *refs):
-    return ["fetch", "-f"] + clone_speedup_options() + [source, *refs] 
+    return ["fetch", "-f"] + clone_speedup_options() + [source, *refs]
 
   def setWriteUrlCmd(self, url):
     return ["remote", "set-url", "--push", "origin", url]

--- a/alibuild_helpers/git.py
+++ b/alibuild_helpers/git.py
@@ -8,8 +8,13 @@ GIT_COMMAND_TIMEOUT_SEC = 120
 """How many seconds to let any git command execute before being terminated."""
 
 
+# Don't recalculate this every time we need it.
+_clone_speedup_cache = None
 def clone_speedup_options():
   """Return a list of options supported by the system git which speed up cloning."""
+  if _clone_speedup_cache is not None:
+    return _clone_speedup_cache
+
   for filter_option in ("--filter=tree:0", "--filter=blob:none"):
     _, out = getstatusoutput("LANG=C git clone " + filter_option)
     if "unknown option" not in out and "invalid filter-spec" not in out:
@@ -63,7 +68,7 @@ class Git(SCM):
     return ["checkout", "-f", ref]
 
   def fetchCmd(self, source, *refs):
-    return ["fetch", "-f", source, *refs]
+    return ["fetch", "-f"] + clone_speedup_options() + [source, *refs] 
 
   def setWriteUrlCmd(self, url):
     return ["remote", "set-url", "--push", "origin", url]

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -111,7 +111,7 @@ GIT_SET_URL_ZLIB_ARGS = ("remote", "set-url", "--push", "origin", "https://githu
 GIT_CHECKOUT_ZLIB_ARGS = ("checkout", "-f", "master"), \
     "/sw/SOURCES/zlib/v1.2.3/8822efa61f", False
 
-GIT_FETCH_REF_ROOT_ARGS = ("fetch", "-f", "https://github.com/root-mirror/root", "+refs/tags/*:refs/tags/*",
+GIT_FETCH_REF_ROOT_ARGS = ("fetch", "-f", "--filter=blob:none", "https://github.com/root-mirror/root", "+refs/tags/*:refs/tags/*",
                            "+refs/heads/*:refs/heads/*"), "/sw/MIRROR/root", False
 GIT_CLONE_SRC_ROOT_ARGS = ("clone", "-n", "https://github.com/root-mirror/root",
                            "/sw/SOURCES/ROOT/v6-08-30/f7b3366117",

--- a/tests/test_workarea.py
+++ b/tests/test_workarea.py
@@ -63,7 +63,7 @@ class WorkareaTestCase(unittest.TestCase):
         mock_exists.assert_has_calls([])
         mock_makedirs.assert_called_with("%s/sw/MIRROR" % getcwd(), exist_ok=True)
         mock_git.assert_called_once_with([
-            "fetch", "-f", spec["source"], "+refs/tags/*:refs/tags/*", "+refs/heads/*:refs/heads/*",
+            "fetch", "-f", "--filter=blob:none", spec["source"], "+refs/tags/*:refs/tags/*", "+refs/heads/*:refs/heads/*",
         ], directory="%s/sw/MIRROR/aliroot" % getcwd(), check=False, prompt=True)
         self.assertEqual(spec.get("reference"), "%s/sw/MIRROR/aliroot" % getcwd())
 


### PR DESCRIPTION
This change is not only performance related, it should also fix the missing blob object errors. Fetching with --filter=tree:0 should always be more resilient to missing objects upstream

```
sh-5.1$ git fetch -f https://github.com/alisw/alibuild-recipe-tools
+refs/tags/*:refs/tags/* +refs/heads/*:refs/heads/*
remote: Enumerating objects: 8, done.
remote: Counting objects: 100% (8/8), done.
remote: Compressing objects: 100% (4/4), done.
remote: Total 6 (delta 2), reused 6 (delta 2), pack-reused 0
Unpacking objects: 100% (6/6), 806 bytes | 806.00 KiB/s, done.
fatal: missing blob object '6f314120ba0359d1f73ad7d1d4a7f171fb36e8ac'
error: https://github.com/alisw/alibuild-recipe-tools did not send all necessary objects
```