### PR TITLE
Support actual CVMFS stores

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -899,12 +899,18 @@ def doBuild(args, parser):
 
     # Now that we have all the information about the package we want to build, let's
     # check if it wasn't built / unpacked already.
-    hashFile = "%s/%s/%s/%s-%s/.build-hash" % (workDir,
-                                               args.architecture,
-                                               spec["package"],
-                                               spec["version"],
-                                               spec["revision"])
-    fileHash = readHashFile(hashFile)
+    hashPath= "%s/%s/%s/%s-%s" % (workDir,
+                                  args.architecture,
+                                  spec["package"],
+                                  spec["version"],
+                                  spec["revision"])
+    hashFile = hashPath + "/.build-hash"
+    # If the folder is a symlink, we consider it to be to CVMFS and
+    # take the hash for good.
+    if os.path.islink(hashPath):
+      fileHash = spec["hash"]
+    else:
+      fileHash = readHashFile(hashFile)
     # Development packages have their own rebuild-detection logic above.
     # spec["hash"] is only useful here for regular packages.
     if fileHash == spec["hash"] and not spec["is_devel_pkg"]:

--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -348,7 +348,10 @@ class CVMFSRemoteSync:
     for install_path in $(find "{remote_store}/{architecture}/{package}" -type d -mindepth 1 -maxdepth 1); do
       full_version="${{install_path##*/}}"
       tarball={package}-$full_version.{architecture}.tar.gz
-      pkg_hash=$(cat "${{install_path}}/.build-hash")
+      pkg_hash=$(cat "${{install_path}}/.build-hash" || jq -r '.package.hash' <${{install_path}}/.meta.json)
+      if [ "X$pkg_hash" = X ]; then
+        continue
+      fi
       ln -sf ../../{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball "{workDir}/{links_path}/$tarball"
       # Create the dummy tarball, if it does not exists
       test -f "{workDir}/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball" && continue

--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -325,7 +325,7 @@ class CVMFSRemoteSync:
   def fetch_tarball(self, spec):
     info("Downloading tarball for %s@%s-%s, if available", spec["package"], spec["version"], spec["revision"])
     # If we already have a tarball with any equivalent hash, don't check S3.
-    for pkg_hash in spec["remote_hashes"]:
+    for pkg_hash in spec["remote_hashes"] + spec["local_hashes"]:
       store_path = resolve_store_path(self.architecture, pkg_hash)
       pattern = os.path.join(self.workdir, store_path, "%s-*.tar.gz" % spec["package"])
       if glob.glob(pattern):


### PR DESCRIPTION
Support actual CVMFS stores

So far the cvmfs:// local store was actually supporting local installation
areas since installation layout in CVMFS is slightly different. We adapt to
support the proper CVMFS layout.

In the future we should probably have a separate mode for referring
to a non CVMFS layout.
