### PR TITLE
Fully support Ubuntu 24.04

### DIFF
--- a/alibuild_helpers/args.py
+++ b/alibuild_helpers/args.py
@@ -377,6 +377,7 @@ On Linux, x86-64:
    RHEL9 / ALMA9 compatible: slc9_x86-64
    Ubuntu 20.04 compatible: ubuntu2004_x86-64
    Ubuntu 22.04 compatible: ubuntu2204_x86-64
+   Ubuntu 24.04 compatible: ubuntu2404_x86-64
    Fedora 33 compatible: fedora33_x86-64
    Fedora 34 compatible: fedora34_x86-64
 
@@ -391,8 +392,8 @@ On Mac, 1-2 latest supported OSX versions:
    Apple Silicon: osx_arm64
 """
 
-# When updating this variable, also update docs/user.markdown!
-S3_SUPPORTED_ARCHS = "slc7_x86-64", "slc8_x86-64", "ubuntu2004_x86-64", "ubuntu2204_x86-64", "slc9_x86-64", "slc9_aarch64"
+# When updating this variable, also update docs/docs/user.md!
+S3_SUPPORTED_ARCHS = "slc7_x86-64", "slc8_x86-64", "ubuntu2004_x86-64", "ubuntu2204_x86-64", "ubuntu2404_x86-64", "slc9_x86-64", "slc9_aarch64"
 
 def finaliseArgs(args, parser):
 

--- a/docs/docs/user.md
+++ b/docs/docs/user.md
@@ -103,7 +103,7 @@ provides tarballs for the most common supported architectures.
 ## Using precompiled packages
 
 By running aliBuild with no special option on CentOS/Alma 7, 8 or 9, or on
-Ubuntu 20.04 or 22.04, it will automatically try to
+Ubuntu 20.04, 22.04 or 24.04, it will automatically try to
 use as many precompiled packages as possible by downloading them from a default
 central server. By using precompiled packages you lose the ability to pick some
 of them from your system. If you do not want to use precompiled packages and you


### PR DESCRIPTION
Finish the Ubuntu 24.04 integration. Closes [O2-5108](https://its.cern.ch/jira/browse/O2-5108)

Set as draft until the S3 artifacts are actually available