### PR TITLE
Fall back to building the package if prefer_system_check fails

### DIFF
--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -493,27 +493,28 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
             if re.match(replacement_matcher, key):
               replacement = spec["prefer_system_replacement_specs"][replacement_matcher]
               break
-          dieOnError(replacement is None, "Could not find named replacement spec for "
-                     "%s: %s" % (spec["package"], key))
-          assert(replacement)
-          # We must keep the package name the same, since it is used to
-          # specify dependencies.
-          replacement["package"] = spec["package"]
-          # The version is required for all specs. What we put there will
-          # influence the package's hash, so allow the user to override it.
-          replacement.setdefault("version", requested_version)
-          spec = replacement
-          # Allows generalising the version based on the actual key provided
-          spec["version"] = spec["version"].replace("%(key)s", key)
-          recipe = replacement.get("recipe", "")
-          # If there's an explicitly-specified recipe, we're still building
-          # the package. If not, aliBuild will still "build" it, but it's
-          # basically instantaneous, so report to the user that we're taking
-          # it from the system.
-          if recipe:
-            ownPackages.add(spec["package"])
+          if replacement:
+            # We must keep the package name the same, since it is used to
+            # specify dependencies.
+            replacement["package"] = spec["package"]
+            # The version is required for all specs. What we put there will
+            # influence the package's hash, so allow the user to override it.
+            replacement.setdefault("version", requested_version)
+            spec = replacement
+            # Allows generalising the version based on the actual key provided
+            spec["version"] = spec["version"].replace("%(key)s", key)
+            recipe = replacement.get("recipe", "")
+            # If there's an explicitly-specified recipe, we're still building
+            # the package. If not, aliBuild will still "build" it, but it's
+            # basically instantaneous, so report to the user that we're taking
+            # it from the system.
+            if recipe:
+              ownPackages.add(spec["package"])
+            else:
+              systemPackages.add(spec["package"])
           else:
-            systemPackages.add(spec["package"])
+            warning(f"Could not find named replacement spec for {spec['package']}: {key}, "
+                    "falling back to building the package ourselves.")
 
     dieOnError(("system_requirement" in spec) and recipe.strip("\n\t "),
                "System requirements %s cannot have a recipe" % spec["package"])

--- a/tests/test_packagelist.py
+++ b/tests/test_packagelist.py
@@ -154,17 +154,20 @@ class ReplacementTestCase(unittest.TestCase):
         self.assertNotIn("with-replacement-recipe", systemPkgs)
         self.assertIn("with-replacement-recipe", ownPkgs)
 
-    @mock.patch("alibuild_helpers.utilities.dieOnError")
-    def test_missing_replacement_spec(self, mock_dieOnError):
-        """Check an error is thrown when the replacement spec is not found."""
-        assert_msg = "Could not find named replacement spec for missing-spec: missing_tag"
-        # Change the behaviour from sys.exit to a regular exception. Without it
-        # we don't stop execution properly and other asserts might trigger
-        mock_dieOnError.side_effect = lambda cond, _: (_ for _ in ()).throw(Exception("dieOnError called")) if cond else None
-        with self.assertRaises(Exception, msg=assert_msg) as context:
-            specs, systemPkgs, ownPkgs, failedReqs, validDefaults = \
-                getPackageListWithDefaults(["missing-spec"])
-        self.assertEqual(str(context.exception), "dieOnError called", msg=assert_msg)
+    @mock.patch("alibuild_helpers.utilities.warning")
+    def test_missing_replacement_spec(self, mock_warning):
+        """Check a warning is displayed when the replacement spec is not found."""
+        warning_msg = "falling back to building the package ourselves"
+        warning_exists = False
+        def side_effect(msg, *args, **kwargs):
+            nonlocal warning_exists
+            if warning_msg in str(msg):
+              warning_exists = True
+        mock_warning.side_effect = side_effect
+        specs, systemPkgs, ownPkgs, failedReqs, validDefaults = \
+            getPackageListWithDefaults(["missing-spec"])
+        self.assertTrue(warning_exists)
+
 
 
 @mock.patch("alibuild_helpers.utilities.getRecipeReader", new=MockReader)


### PR DESCRIPTION
The current behaviour is to crash the build, but we can recover
gracefully by going back to building our own version instead.

Any trigger of this warning should be considered as a bug on the recipe,
though