### PR TITLE
Dump some system info on error

### DIFF
--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -4,7 +4,7 @@ from alibuild_helpers import __version__
 from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, info, banner, warning
 from alibuild_helpers.log import dieOnError
-from alibuild_helpers.cmd import execute, DockerRunner, BASH, install_wrapper_script
+from alibuild_helpers.cmd import execute, DockerRunner, BASH, install_wrapper_script, getstatusoutput
 from alibuild_helpers.utilities import prunePaths, symlink, call_ignoring_oserrors, topological_sort, detectArch
 from alibuild_helpers.utilities import resolve_store_path
 from alibuild_helpers.utilities import parseDefaults, readDefaults
@@ -1123,11 +1123,17 @@ def doBuild(args, parser):
         "remoteStore"
           }
       args_str = " ".join(f"--{k}={v}" for k, v in vars(args).items() if v and k in safe_args)
+      detected_arch = detectArch()
       buildErrMsg += dedent(f"""
       Build info:
+      OS: {detected_arch}
       Using aliBuild from alibuild@{__version__ or "unknown"} recipes in alidist@{os.environ["ALIBUILD_ALIDIST_HASH"][:10]}
       Build arguments: {args_str}
       """)
+
+      if detected_arch.startswith("osx"):
+        buildErrMsg += f'XCode version: {getstatusoutput("xcodebuild -version")[1]}'
+
     except Exception as exc:
       warning("Failed to gather build info", exc_info=exc)
 

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -1119,8 +1119,7 @@ def doBuild(args, parser):
       safe_args = {
         "pkgname", "defaults", "architecture", "forceUnknownArch",
         "develPrefix", "jobs", "noSystem", "noDevel", "forceTracked", "plugin",
-        "disable", "annotate", "onlyDeps", "docker", "docker_extra_args",
-        "remoteStore"
+        "disable", "annotate", "onlyDeps", "docker"
           }
       args_str = " ".join(f"--{k}={v}" for k, v in vars(args).items() if v and k in safe_args)
       detected_arch = detectArch()

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -5,7 +5,7 @@ from alibuild_helpers.analytics import report_event
 from alibuild_helpers.log import debug, info, banner, warning
 from alibuild_helpers.log import dieOnError
 from alibuild_helpers.cmd import execute, DockerRunner, BASH, install_wrapper_script
-from alibuild_helpers.utilities import prunePaths, symlink, call_ignoring_oserrors, topological_sort
+from alibuild_helpers.utilities import prunePaths, symlink, call_ignoring_oserrors, topological_sort, detectArch
 from alibuild_helpers.utilities import resolve_store_path
 from alibuild_helpers.utilities import parseDefaults, readDefaults
 from alibuild_helpers.utilities import getPackageList, asList
@@ -413,6 +413,8 @@ def create_provenance_info(package, specs, args):
 
   def dependency_list(key):
     return [spec_info(specs[dep]) for dep in specs[package].get(key, ())]
+
+  a = os.environ["ALIBUILD_ALIDIST_HASH"]
 
   return json.dumps({
     "comment": args.annotate.get(package),
@@ -1111,6 +1113,24 @@ def doBuild(args, parser):
       To update all development packages required for this build it is usually sufficient to do:
       """)
       buildErrMsg += "".join("\n  ( cd %s && git pull --rebase )" % dp for dp in updatablePkgs)
+
+    # Gather build info for the error message
+    try:
+      safe_args = {
+        "pkgname", "defaults", "architecture", "forceUnknownArch",
+        "develPrefix", "jobs", "noSystem", "noDevel", "forceTracked", "plugin",
+        "disable", "annotate", "onlyDeps", "docker", "docker_extra_args",
+        "remoteStore"
+          }
+      args_str = " ".join(f"--{k}={v}" for k, v in vars(args).items() if v and k in safe_args)
+      buildErrMsg += dedent(f"""
+      Build info:
+      Using aliBuild from alibuild@{__version__ or "unknown"} recipes in alidist@{os.environ["ALIBUILD_ALIDIST_HASH"][:10]}
+      Build arguments: {args_str}
+      """)
+    except Exception as exc:
+      warning("Failed to gather build info", exc_info=exc)
+
 
     dieOnError(err, buildErrMsg.strip())
 

--- a/alibuild_helpers/build.py
+++ b/alibuild_helpers/build.py
@@ -414,8 +414,6 @@ def create_provenance_info(package, specs, args):
   def dependency_list(key):
     return [spec_info(specs[dep]) for dep in specs[package].get(key, ())]
 
-  a = os.environ["ALIBUILD_ALIDIST_HASH"]
-
   return json.dumps({
     "comment": args.annotate.get(package),
     "alibuild_version": __version__,


### PR DESCRIPTION
Should make debugging logs easier

~~Still left to implement:~~

- [x] Add XCode version in case of macOS


@ktf do you agree with the safe_args list? I think none should be leaking any secrets, but maybe docker_extra_args can?

Example output:

```
2024-11-18@13:55:57:ERROR:json-c:json-c:slc9_aarch64: Error while executing /alibuild/sw/SPECS/slc9_aarch64/json-c/v0.17.0-local1/build.sh on `alimachine'.
2024-11-18@13:55:57:ERROR:json-c:json-c:slc9_aarch64: Log can be found in /alibuild/sw/BUILD/json-c-latest/log
2024-11-18@13:55:57:ERROR:json-c:json-c:slc9_aarch64: Please upload it to CERNBox/Dropbox if you intend to request support.
2024-11-18@13:55:57:ERROR:json-c:json-c:slc9_aarch64: Build directory is /alibuild/sw/BUILD/json-c-latest/json-c.
2024-11-18@13:55:57:ERROR:json-c:json-c:slc9_aarch64:
2024-11-18@13:55:57:ERROR:json-c:json-c:slc9_aarch64: Build info:
2024-11-18@13:55:57:ERROR:json-c:json-c:slc9_aarch64: Using aliBuild from alibuild@1.17.12.dev12+ge4cc2be.d20241029 recipes in alidist@237786d35a11d8130c6edf43e11128f305367a2a
2024-11-18@13:55:57:ERROR:json-c:json-c:slc9_aarch64: Build arguments: --debug=True --action=build --pkgname=['json-c'] --defaults=o2 --architecture=slc9_aarch64 --jobs=12 --plugin=legacy --disable=['mesos', 'MySQL', 'make', 'yacc-like', 'make'] --docker=True --dockerImage=registry.cern.ch/alisw/slc9-builder --docker_extra_args=['--network=host'] --remoteStore=https://s3.cern.ch/swift/v1/alibuild-repo --chdir=. --workDir=sw --configDir=alidist --referenceSources=sw/MIRROR --autoCleanup=True --noSystem=True --develPrefix=slc9_aarch64
```