### PR TITLE
Ensure spec["version"] is a string before trying to expand it

### DIFF
--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -123,7 +123,7 @@ def resolve_version(spec, defaults, branch_basename, branch_stream):
   defaults_upper = defaults != "release" and "_" + defaults.upper().replace("-", "_") or ""
   commit_hash = spec.get("commit_hash", "hash_unknown")
   tag = str(spec.get("tag", "tag_unknown"))
-  return spec["version"] % {
+  return str(spec["version"]) % {
     "commit_hash": commit_hash,
     "short_hash": commit_hash[0:10],
     "tag": tag,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -226,6 +226,12 @@ class TestUtilities(unittest.TestCase):
     self.assertTrue(resolve_version(spec, "o2", "stream/v1", "v1"), "O2")
     spec["version"] = "NO%(defaults_upper)s"
     self.assertTrue(resolve_version(spec, "release", "stream/v1", "v1"), "NO")
+    spec_float_version = {"package": "test-pkg",
+      "version": 1.0,
+      "tag": "foo/bar",
+      "commit_hash": "000000000000000000000000000"
+    }
+    self.assertTrue(resolve_version(spec_float_version, "release", "stream/v1", "v1"), "NO")
 
 
 class TestTopologicalSort(unittest.TestCase):


### PR DESCRIPTION
Some valid versions defined in the recipe can be parsed as floats
instead (e.g. 1.0)

Fix by @mborisyak

Closes https://github.com/alisw/alibuild/issues/887

Further discussion here: https://github.com/ShipSoft/shipdist/issues/94