### PR TITLE
Fixes #887 by raising an informative exception when version is not a string

### DIFF
--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -123,6 +123,15 @@ def resolve_version(spec, defaults, branch_basename, branch_stream):
   defaults_upper = defaults != "release" and "_" + defaults.upper().replace("-", "_") or ""
   commit_hash = spec.get("commit_hash", "hash_unknown")
   tag = str(spec.get("tag", "tag_unknown"))
+  version = spec["version"]
+  if not isinstance(version, str):
+    raise ValueError(
+      "Version for the package {package} must be a string, got {version}. "
+      "Please, make sure the version is quoted in the config file, e.g., \"1.0\"".format(
+        package=spec.get("package", "package_unknown"),
+        version=version
+      )
+    )
   return spec["version"] % {
     "commit_hash": commit_hash,
     "short_hash": commit_hash[0:10],

--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -132,7 +132,7 @@ def resolve_version(spec, defaults, branch_basename, branch_stream):
         version=version
       )
     )
-  return spec["version"] % {
+  return version % {
     "commit_hash": commit_hash,
     "short_hash": commit_hash[0:10],
     "tag": tag,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -227,6 +227,16 @@ class TestUtilities(unittest.TestCase):
     spec["version"] = "NO%(defaults_upper)s"
     self.assertTrue(resolve_version(spec, "release", "stream/v1", "v1"), "NO")
 
+    spec_float_version = {"package": "test-pkg",
+                          "version": 1.0,
+                          "tag": "foo/bar",
+                          "commit_hash": "000000000000000000000000000"
+                          }
+    self.assertRaises(
+      ValueError,
+      lambda: resolve_version(spec_float_version, "release", "stream/v1", "v1")
+    )
+
 
 class TestTopologicalSort(unittest.TestCase):
     """Check that various properties of topological sorting hold."""


### PR DESCRIPTION
Resolver raises a ValueError with the package name when the version is not a string.
This might happen when the version is not quoted and yaml parses it as a float.

Adapted from the version by @singiamtel 
Replaces #888 
Closes #887 