### PR TITLE
Fix macOS CI runner

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -66,7 +66,7 @@ jobs:
 
   mac-unittest:
     name: mac-python${{ matrix.python-version }}
-    runs-on: macos-latest
+    runs-on: macos-14
 
     strategy:
       fail-fast: false   # continue executing other checks if one fails
@@ -84,6 +84,9 @@ jobs:
 
       - name: Install test dependencies
         run: |
+          # Hack to remove whatever the CI default image brings now, as it
+          # conflicts with the one in o2-full-deps [O2-5580]
+          brew uninstall --ignore-dependencies --force pkg-config@0.29.2 
           brew install modules alisw/system-deps/o2-full-deps sapling
           python3 -m pip install --upgrade tox tox-gh-actions coverage
 

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Upload coverage information
         if: ${{ always() && github.event.repository.owner.login == 'alisw' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.json
 
@@ -75,10 +75,10 @@ jobs:
           - '3.11'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -105,7 +105,7 @@ jobs:
 
       - name: Upload coverage information
         if: ${{ always() && github.event.repository.owner.login == 'alisw' }}
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         with:
           files: coverage.json
 
@@ -114,10 +114,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.x
 


### PR DESCRIPTION
Something changed in the default GitHub runners image again, and broke our setup

https://github.com/actions/runner-images/issues/10984

Error logs:

```
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /opt/homebrew
Could not symlink bin/pkg-config
Target /opt/homebrew/bin/pkg-config
is a symlink belonging to pkg-config@0.29.2. You can unlink it:
  brew unlink pkg-config@0.29.2

To force the link and overwrite all conflicting files:
  brew link --overwrite pkgconf

To list all files that would be deleted:
  brew link --overwrite pkgconf --dry-run

Possible conflicting files are:
/opt/homebrew/bin/pkg-config -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/bin/pkg-config
/opt/homebrew/share/aclocal/pkg.m4 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/aclocal/pkg.m4
/opt/homebrew/share/man/man1/pkg-config.1 -> /opt/homebrew/Cellar/pkg-config@0.29.2/0.29.2_3/share/man/man1/pkg-config.1
```