### PR TITLE
Handle changes in argparse

### DIFF
--- a/tests/test_args.py
+++ b/tests/test_args.py
@@ -8,6 +8,7 @@ from alibuild_helpers.args import doParseArgs, matchValidArch, finaliseArgs, DEF
 import sys
 import os
 import os.path
+import re
 
 import unittest
 import shlex
@@ -16,18 +17,18 @@ BUILD_MISSING_PKG_ERROR = "the following arguments are required: PACKAGE"
 ANALYTICS_MISSING_STATE_ERROR = "the following arguments are required: state"
 
 # A few errors we should handle, together with the expected result
-ARCHITECTURE_ERROR = [call(u"Unknown / unsupported architecture: foo.\n\n{table}Alternatively, you can use the `--force-unknown-architecture' option.".format(table=ARCHITECTURE_TABLE))]
+ARCHITECTURE_ERROR = u"Unknown / unsupported architecture: foo.\n\n.*"
 PARSER_ERRORS = {
-  "build --force-unknown-architecture": [call(BUILD_MISSING_PKG_ERROR)],
-  "build --force-unknown-architecture zlib --foo": [call('unrecognized arguments: --foo')],
-  "init --docker-image": [call('unrecognized arguments: --docker-image')],
-  "builda --force-unknown-architecture zlib" : [call("argument action: invalid choice: 'builda' (choose from 'analytics', 'architecture', 'build', 'clean', 'deps', 'doctor', 'init', 'version')")],
-  "build --force-unknown-architecture zlib --no-system --always-prefer-system" : [call('argument --always-prefer-system: not allowed with argument --no-system')],
+  "build --force-unknown-architecture": BUILD_MISSING_PKG_ERROR,
+  "build --force-unknown-architecture zlib --foo": 'unrecognized arguments: --foo',
+  "init --docker-image": 'unrecognized arguments: --docker-image',
+  "builda --force-unknown-architecture zlib" : "argument action: invalid choice: 'builda'.*",
+  "build --force-unknown-architecture zlib --no-system --always-prefer-system" : 'argument --always-prefer-system: not allowed with argument --no-system',
   "build zlib --architecture foo": ARCHITECTURE_ERROR,
-  "build --force-unknown-architecture zlib --remote-store rsync://test1.local/::rw --write-store rsync://test2.local/::rw ": [call('cannot specify ::rw and --write-store at the same time')],
-  "build zlib -a osx_x86-64 --docker-image foo": [call('cannot use `-a osx_x86-64` and --docker')],
-  "build zlib -a slc7_x86-64 --annotate foobar": [call("--annotate takes arguments of the form PACKAGE=COMMENT")],
-  "analytics": [call(ANALYTICS_MISSING_STATE_ERROR)]
+  "build --force-unknown-architecture zlib --remote-store rsync://test1.local/::rw --write-store rsync://test2.local/::rw ": 'cannot specify ::rw and --write-store at the same time',
+  "build zlib -a osx_x86-64 --docker-image foo": 'cannot use `-a osx_x86-64` and --docker',
+  "build zlib -a slc7_x86-64 --annotate foobar": "--annotate takes arguments of the form PACKAGE=COMMENT",
+  "analytics": ANALYTICS_MISSING_STATE_ERROR
 }
 
 # A few valid archs
@@ -97,11 +98,17 @@ class ArgsTestCase(unittest.TestCase):
   @mock.patch('alibuild_helpers.args.argparse.ArgumentParser.error')
   def test_failingParsing(self, mock_print):
     mock_print.side_effect = FakeExit("raised")
-    for (cmd, calls) in PARSER_ERRORS.items():
+    for (cmd, pattern) in PARSER_ERRORS.items():
       mock_print.mock_calls = []
       with patch.object(sys, "argv", ["alibuild"] + shlex.split(cmd)):
         self.assertRaises(FakeExit, doParseArgs)
-        self.assertEqual(mock_print.mock_calls, calls)
+        for mock_call in mock_print.mock_calls:
+          args = mock_call[1]
+          print(args)
+          self.assertTrue(
+                re.match(pattern, args[0]),
+                f"Expected '{args[0]}' matching '{pattern}' but it's not the case."
+            )
 
   def test_validArchitectures(self):
     for arch in VALID_ARCHS:

--- a/tox.ini
+++ b/tox.ini
@@ -74,7 +74,7 @@ commands =
 
     coverage run --source={toxinidir} -a -m unittest discover {toxinidir}/tests
 
-    git clone -b O2-v1.3.0 --depth 1 https://github.com/alisw/alidist
+    git clone -b alibuild_CI --depth 1 https://github.com/alisw/alidist
 
     coverage run --source={toxinidir} -a {toxinidir}/aliBuild -a {env:ARCHITECTURE} -z test-init init zlib
     # This command is expected to fail, but run it for the coverage anyway.


### PR DESCRIPTION
Use regular expressions to make sure we handle small differences in the error messages due to formatting of the arguments done by different versions of python.