### PR TITLE
Remove python2.7 test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.20
-envlist = lint, py{27, 36, 37, 38, 39, 310, 311, 312, 313}, darwin
+envlist = lint, py{36, 37, 38, 39, 310, 311, 312, 313}, darwin
 
 [gh-actions]
 # The "lint" job is run separately.


### PR DESCRIPTION
Oversight from the migration
