### PR TITLE
Don't redefine profiler variable to incompatible type

### DIFF
--- a/aliBuild
+++ b/aliBuild
@@ -111,8 +111,8 @@ if __name__ == "__main__":
   else:
     os.environ["ALIBUILD_ANALYTICS_USER_UUID"] = open(expanduser("~/.config/alibuild/analytics-uuid")).read().strip()
   try:
-    profiler = "--profile" in sys.argv
-    if profiler:
+    useProfiler = "--profile" in sys.argv
+    if useProfiler:
       print("profiler started")
       import cProfile, pstats
       from io import StringIO


### PR DESCRIPTION
Fixes `Type "bool" is incompatible with type "() -> None"`

As discussed in
https://github.com/alisw/alibuild/pull/882/files#r1851624332
