### PR TITLE
Don't initialize the loggers to None

### DIFF
--- a/alibuild_helpers/log.py
+++ b/alibuild_helpers/log.py
@@ -4,8 +4,6 @@ import re
 import time
 import datetime
 
-debug, error, warning, info, success = (None, None, None, None, None)
-
 def dieOnError(err, msg) -> None:
   if err:
     error("%s", msg)


### PR DESCRIPTION
It confuses the typing check

As discussed beforehand, my goal is to eventually pass these strict mypy filter settings

I'll be tracking the progress in each PR, and try to fix the low hanging fruit first

```diff
-Found 788 errors in 33 files (checked 35 source files)
+Found 664 errors in 33 files (checked 35 source files)
```

The mypy filter

```ini
[mypy]
python_version = 3.12
platform = linux
plugins = pydantic.mypy
show_error_codes = true
follow_imports = normal
local_partial_types = true
strict_equality = true
no_implicit_optional = true
warn_incomplete_stub = true
warn_redundant_casts = true
warn_unused_configs = true
warn_unused_ignores = true
enable_error_code = ignore-without-code, redundant-self, truthy-iterable
disable_error_code = annotation-unchecked, import-not-found, import-untyped
extra_checks = false
check_untyped_defs = true
disallow_incomplete_defs = true
disallow_subclassing_any = true
disallow_untyped_calls = true
disallow_untyped_decorators = true
disallow_untyped_defs = true
warn_return_any = true
warn_unreachable = true

[pydantic-mypy]
init_forbid_extra = true
init_typed = true
warn_required_dynamic_aliases = true
warn_untyped_fields = true
```
