### PR TITLE
Don't restrict boto3 as much

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
   'requests',
   'distro',
   'jinja2',
-  'boto3==1.23.10',
+  'boto3<1.36.0',
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,4 @@ pyyaml
 distro
 jinja2
 # https://github.com/boto/boto3/issues/4398
-# This version is the last compatible with python 3.6.8
-boto3==1.23.10; python_version >= '3.6'
+boto3<1.36.0

--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,7 @@ here = os.path.abspath(os.path.dirname(__file__))
 with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-install_requires = ['pyyaml', 'requests', 'distro', 'jinja2']
-# Old setuptools versions (which pip2 uses) don't support range comparisons
-# (like :python_version >= "3.6") in extras_require, so do this ourselves here.
-if sys.version_info >= (3, 6):
-    install_requires.append('boto3==1.23.10')
+install_requires = ['pyyaml', 'requests', 'distro', 'jinja2', 'boto3<1.36.0']
 
 setup(
     name='alibuild',


### PR DESCRIPTION
This should allow us to bypass the removed cgi error (botocore removed
the dependency in 1.29.13)
