### PR TITLE
Make sure recipe file exists before accessing it

### DIFF
--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -307,7 +307,7 @@ def readDefaults(configDir, defaults, error, architecture):
   return (defaultsMeta, defaultsBody)
 
 
-def getRecipeReader(url, dist=None):
+def getRecipeReader(url:str , dist=None):
   m = re.search(r'^dist:(.*)@([^@]+)$', url)
   if m and dist:
     return GitReader(url, dist)
@@ -453,6 +453,9 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
     pkg_filename = ("defaults-" + defaults) if p == "defaults-release" else p.lower()
 
     filename, pkgdir = resolveFilename(taps, pkg_filename, configDir)
+
+    dieOnError(not filename, "Package %s not found in %s" % (p, configDir))
+    assert(filename is not None)
 
     err, spec, recipe = parseRecipe(getRecipeReader(filename, configDir))
     dieOnError(err, err)


### PR DESCRIPTION
Looks like a regression in #897

```bash
[root@56a05890a2a6 ~]# uvx aliBuild@1.17.14 build bogus
ERROR: [Errno 2] No such file or directory: 'alidist/bogus.sh'

[root@56a05890a2a6 ~]# uvx aliBuild@1.17.15 build bogus
Traceback (most recent call last):
  File "/root/.cache/uv/archive-v0/GyJkpyQa9tPugmoKbsZ3N/bin/aliBuild", line 132, in <module>
    doMain(args, parser)
  File "/root/.cache/uv/archive-v0/GyJkpyQa9tPugmoKbsZ3N/bin/aliBuild", line 85, in doMain
    doBuild(args, parser)
  File "/root/.cache/uv/archive-v0/GyJkpyQa9tPugmoKbsZ3N/lib64/python3.9/site-packages/alibuild_helpers/build.py", line 490, in doBuild
    getPackageList(packages                = packages,
  File "/root/.cache/uv/archive-v0/GyJkpyQa9tPugmoKbsZ3N/lib64/python3.9/site-packages/alibuild_helpers/utilities.py", line 457, in getPackageList
    err, spec, recipe = parseRecipe(getRecipeReader(filename, configDir))
  File "/root/.cache/uv/archive-v0/GyJkpyQa9tPugmoKbsZ3N/lib64/python3.9/site-packages/alibuild_helpers/utilities.py", line 311, in getRecipeReader
    m = re.search(r'^dist:(.*)@([^@]+)$', url)
  File "/usr/lib64/python3.9/re.py", line 201, in search
    return _compile(pattern, flags).search(string)
TypeError: expected string or bytes-like object
```
