### PR TITLE
Prefer system check which result in a new recipe should be treated as normal packages

### DIFF
--- a/alibuild_helpers/utilities.py
+++ b/alibuild_helpers/utilities.py
@@ -504,8 +504,8 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
       noSystemList = [spec["package"]]
     elif noSystem is not None:
       noSystemList = noSystem.split(",")
-
-    if (spec["package"] not in noSystemList) and (preferSystem or systemREMatches):
+    systemExcluded = (spec["package"] in noSystemList)
+    if (preferSystem or systemREMatches):
       requested_version = resolve_version(spec, defaults, "unavailable", "unavailable")
       cmd = "REQUESTED_VERSION={version}\n{check}".format(
         version=quote(requested_version),
@@ -520,12 +520,16 @@ def getPackageList(packages, specs, configDir, preferSystem, noSystem,
       else:
         # prefer_system_check succeeded; this means we should use the system package.
         match = re.search(r"^alibuild_system_replace:(?P<key>.*)$", output, re.MULTILINE)
-        if not match:
+        if not match and systemExcluded:
+          # No replacement spec name given. Fall back to old system package
+          # behaviour and just disable the package.
+          ownPackages.add(spec["package"])
+        elif not match and not systemExcluded:
           # No replacement spec name given. Fall back to old system package
           # behaviour and just disable the package.
           systemPackages.add(spec["package"])
           disable.append(spec["package"])
-        else:
+        elif match:
           # The check printed the name of a replacement; use it.
           key = match.group("key").strip()
           replacement = None


### PR DESCRIPTION

In general when are remote store is provided, we disable system packages. However, this
should not be the case if the system package results in a new recipe, because in that case
we consider the result of that recipe to be the package.
