### PR TITLE
Change entrypoint of aliBuild

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,30 +9,26 @@ permissions:
   contents: read  # required for github.ref to be set
 
 jobs:
-  pypi:
-    name: Publish release on PyPI
+  pypi-publish:
+    name: Upload release to PyPI
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    environment:
+      name: pypi
+      url: https://pypi.org/p/alibuild
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
-      - name: Checkout alibuild
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Install build dependencies   # needed by our setup.py
-        run: python -m pip install setuptools
-      - name: Build the Python distribution
-        run: python setup.py sdist
-      - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.5.0
-        with:
-          user: __token__
-          password: ${{ secrets.pypi_password }}
+    # retrieve your distributions here
+    - name: Install build dependencies
+      run: python -m pip install --upgrade setuptools build pip
+    - name: Build the Python distribution
+      run: python -m build
+    - name: Publish package distributions to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
 
   brew:
     name: Update Homebrew formula
-    needs: pypi
+    needs: pypi-publish
     runs-on: macos-latest
     if: startsWith(github.ref, 'refs/tags/') && !github.event.release.prerelease
     steps:

--- a/PACKAGING.md
+++ b/PACKAGING.md
@@ -7,12 +7,5 @@ alibuild is available from PyPi. Package page at:
 In order to publish a new version:
 
 - Test, test, test.
-- Change the tag in setup.py
-- Build the source distribution with:
-
-      python setup.py build sdist
-
-- Publish with:
-
-      twine upload dist/*
-
+- Create a new release in GitHub.
+- The github action shoul automatically create a new release and upload the package to PyPi (it's a good idea to verify that the release was created and the package uploaded).

--- a/alfaBuild
+++ b/alfaBuild
@@ -1,1 +1,0 @@
-aliBuild

--- a/aliDeps
+++ b/aliDeps
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-import sys
-import os
-from os.path import dirname, join, abspath
-if __name__ == "__main__":
-  aliBuild = join(dirname(abspath(sys.argv[0])), "aliBuild")
-  os.execv(aliBuild, [ aliBuild, "deps" ] + sys.argv[1:])

--- a/aliDoctor
+++ b/aliDoctor
@@ -1,7 +1,0 @@
-#!/usr/bin/env python3
-import sys
-import os
-from os.path import dirname, join, abspath
-if __name__ == "__main__":
-  aliBuild = join(dirname(abspath(sys.argv[0])), "aliBuild")
-  os.execv(aliBuild, [ aliBuild, "doctor" ] + sys.argv[1:])

--- a/alibuild_helpers/main.py
+++ b/alibuild_helpers/main.py
@@ -83,7 +83,11 @@ def doMain(args, parser):
     sys.exit(0)
 
 
-if __name__ == "__main__":
+def main(action = None):
+  if action:
+    sys.argv[0] = "aliBuild"
+    sys.argv.insert(1, action)
+
   args, parser = doParseArgs()
 
   # This is valid for everything
@@ -135,3 +139,15 @@ if __name__ == "__main__":
     traceback.print_exc()
     report_exception(e)
     exit(1)
+
+def doctor_main():
+    main(action="doctor")
+
+def alideps_main():
+    main(action="deps")
+
+def pb_main():
+    main()
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,18 @@ dependencies = [
   'boto3<1.36.0',
 ]
 
+[project.scripts]
+aliBuild = "alibuild_helpers.main:main"
+aliDoctor = "alibuild_helpers.main:doctor_main"
+aliDeps = "alibuild_helpers.main:alideps_main"
+pb = "alibuild_helpers.main:pb_main"
+
 [project.urls]
 homepage = 'https://alisw.github.io/alibuild'
 
+
 [tool.setuptools]
-script-files = ["aliBuild", "alienv", "aliDoctor", "aliDeps", "pb"]
+script-files = ["alienv"]
 
 [tool.setuptools_scm]
 write_to = "alibuild_helpers/_version.py"
@@ -47,3 +54,4 @@ exclude = ["yaml"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.rst"]}
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,12 @@ dependencies = [
 aliBuild = "alibuild_helpers.main:main"
 aliDoctor = "alibuild_helpers.main:doctor_main"
 aliDeps = "alibuild_helpers.main:alideps_main"
-pb = "alibuild_helpers.main:pb_main"
+# Just aliases, for backwards compatibility
+alfaBuild = "alibuild_helpers.main:main"
+pb = "alibuild_helpers.main:main"
 
 [project.urls]
 homepage = 'https://alisw.github.io/alibuild'
-
 
 [tool.setuptools]
 script-files = ["alienv"]


### PR DESCRIPTION
This PR does the following:

# Change entrypoint of aliBuild

pyproject.toml has a `[project.scripts]` section that defines the entry point for the aliBuild command. This let's us get rid of the helper scripts we used to have.

We could keep `/aliBuild` as an alias to `/alibuild_helpers/main.py` in order not to break muscle memory, I have no preference. 

Otherwise you'd need to run `pip install -e .`, and then `aliBuild` should point to the local one.

# Update release workflow for pyproject.toml

We still had the old `setup.py` in the release workflow. This is now replaced by a call to `build` which will use the `pyproject.toml` file to build the package.
