### PR TITLE
Run prefer_system_check in a temporary dir

### DIFF
--- a/alibuild_helpers/cmd.py
+++ b/alibuild_helpers/cmd.py
@@ -37,9 +37,9 @@ def getoutput(command, timeout=None):
   return decode_with_fallback(stdout)
 
 
-def getstatusoutput(command, timeout=None):
+def getstatusoutput(command, timeout=None, cwd=None):
   """Run command and return its return code and output (stdout and stderr)."""
-  proc = Popen(command, shell=isinstance(command, str), stdout=PIPE, stderr=STDOUT)
+  proc = Popen(command, shell=isinstance(command, str), stdout=PIPE, stderr=STDOUT, cwd=cwd)
   try:
     merged_output, _ = proc.communicate(timeout=timeout)
   except TimeoutExpired:
@@ -91,11 +91,12 @@ class DockerRunner:
       cmd += [self._docker_image, "sleep", "inf"]
       self._container = getoutput(cmd).strip()
 
-    def getstatusoutput_docker(cmd):
+    def getstatusoutput_docker(cmd, cwd=None):
       if self._container is None:
-        return getstatusoutput("{} -c {}".format(BASH, quote(cmd)))
+        return getstatusoutput("{} -c {}".format(BASH, quote(cmd)), cwd=cwd)
       return getstatusoutput("docker container exec {} bash -c {}"
-                             .format(quote(self._container), quote(cmd)))
+                             .format(quote(self._container), quote(cmd)),
+                             cwd=cwd)
 
     return getstatusoutput_docker
 

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -26,7 +26,7 @@ class CmdTestCase(unittest.TestCase):
             mock_getoutput.assert_called_with(["docker", "run", "--detach", "--rm", "--entrypoint=",
                                                "extra arg", "image", "sleep", "inf"])
             getstatusoutput_docker("echo foo")
-            mock_getstatusoutput.assert_called_with("docker container exec container-id bash -c 'echo foo'")
+            mock_getstatusoutput.assert_called_with("docker container exec container-id bash -c 'echo foo'", cwd=None)
         mock_getstatusoutput.assert_called_with("docker container kill container-id")
 
         mock_getoutput.reset_mock()
@@ -34,7 +34,7 @@ class CmdTestCase(unittest.TestCase):
         with DockerRunner("") as getstatusoutput_docker:
             mock_getoutput.assert_not_called()
             getstatusoutput_docker("echo foo")
-            mock_getstatusoutput.assert_called_with("/bin/bash -c 'echo foo'")
+            mock_getstatusoutput.assert_called_with("/bin/bash -c 'echo foo'", cwd=None)
             mock_getstatusoutput.reset_mock()
         mock_getstatusoutput.assert_not_called()
 

--- a/tests/test_packagelist.py
+++ b/tests/test_packagelist.py
@@ -3,6 +3,7 @@ import unittest
 from unittest import mock
 from unittest.mock import patch
 import os.path
+import tempfile
 
 from alibuild_helpers.cmd import getstatusoutput
 from alibuild_helpers.utilities import getPackageList
@@ -68,8 +69,16 @@ RECIPES = {
     force_rebuild: true
     ---
     """),
+    "CONFIG_DIR/dirty_prefer_system_check.sh": dedent("""\
+    package: dirty_prefer_system_check
+    version: v1
+    prefer_system: .*
+    prefer_system_check: |
+      pwd > HEREE
+      exit 0
+    ---
+    """),
 }
-
 
 class MockReader:
     def __init__(self, url: str, dist=None):
@@ -83,6 +92,9 @@ class MockReader:
 
 def getPackageListWithDefaults(packages, force_rebuild=()):
     specs = {}   # getPackageList will mutate this
+    def performPreferCheckWithTempDir(pkg, cmd):
+      with tempfile.TemporaryDirectory(prefix=f"alibuild_prefer_check_{pkg['package']}_") as temp_dir:
+        return getstatusoutput(cmd, cwd=temp_dir)
     return_values = getPackageList(
         packages=packages,
         specs=specs,
@@ -96,8 +108,8 @@ def getPackageListWithDefaults(packages, force_rebuild=()):
         disable=[],
         defaults="release",
         # Mock recipes just run "echo" or ":", so this is safe.
-        performPreferCheck=lambda spec, cmd: getstatusoutput(cmd),
-        performRequirementCheck=lambda spec, cmd: getstatusoutput(cmd),
+        performPreferCheck=performPreferCheckWithTempDir,
+        performRequirementCheck=performPreferCheckWithTempDir,
         performValidateDefaults=lambda spec: (True, "", ["release"]),
         overrides={"defaults-release": {}},
         taps={},
@@ -182,6 +194,14 @@ class ReplacementTestCase(unittest.TestCase):
                 getPackageListWithDefaults(["missing-spec"])
             self.assertTrue(warning_exists)
 
+    def test_dirty_system_check(self) -> None:
+        """Check that prefer_system_check runs in isolation and doesn't create files in cwd."""
+        def fake_exists(n):
+            return n in RECIPES.keys()
+        with patch.object(os.path, "exists", fake_exists):
+            getPackageListWithDefaults(["dirty_prefer_system_check"])
+            # can't use os.path.exists() ourselves, as we just mocked it
+            self.assertFalse("HEREE" in os.listdir())
 
 
 @mock.patch("alibuild_helpers.utilities.getRecipeReader", new=MockReader)
@@ -207,6 +227,8 @@ class ForceRebuildTestCase(unittest.TestCase):
             )
             self.assertTrue(specs["force-rebuild"]["force_rebuild"])
             self.assertTrue(specs["defaults-release"]["force_rebuild"])
+
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This way we don't leave traces in case the check happened to create
temporary files

CC @ktf @davidrohr 