### PR TITLE
Add job to check readme before merge

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -129,3 +129,22 @@ jobs:
   #
   #     - name: Run linters
   #       run: tox -e lint
+    
+  check-readme:
+    name: Check README
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.x
+
+      - name: Install dependencies
+        run: python -m pip install --upgrade tox tox-gh-actions
+
+      - name: Run README check
+        run: tox -e check-readme
+

--- a/tox.ini
+++ b/tox.ini
@@ -139,3 +139,11 @@ exclude_lines =
     raise NotImplementedError
     # Don't complain if non-runnable code isn't run:
     if __name__ == .__main__.:
+
+[testenv:check-readme]
+# Check the README.rst file for common issues.
+# The pypa publishing job fails if this fails.
+deps =
+    rstcheck
+commands =
+    rstcheck {toxinidir}/README.rst


### PR DESCRIPTION
Seems like a requirement from pypi. It can make the release fail to
publish, so it's better to check early
