### PR TITLE
Homebrew publisher: Don't change the version of the package

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,6 @@ jobs:
           sed -i.bak "
           s|^  url .*|  url \"$url\"|;
           s|^  sha256 .*|  sha256 \"$sha\"|;
-          s|^  version .*|  version \"${GITHUB_REF#refs/tags/v}\"|
           " "$(brew formula alibuild)"
           rm -f "$(brew formula alibuild).bak"
       - name: Regenerate alibuild formula


### PR DESCRIPTION
Brew does this automatically from the URL

Requires https://github.com/alisw/homebrew-system-deps/pull/44 to be merged first
