### PR TITLE
Revert "Fix the license metadata"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,8 +8,7 @@ name = 'alibuild'
 dynamic = ['readme', 'version']
 description = 'ALICE Build Tool'
 keywords = ['HEP', 'ALICE']
-license = "GPL-3.0-only"
-license-files = ["LICENSE[.]md"]
+license = { file = 'LICENSE' }
 authors = [
   {name = 'Giulio Eulisse', email = 'giulio.eulisse@cern.ch'},
   {name = 'Timo Wilken', email = 'timo.wilken@cern.ch'},


### PR DESCRIPTION
This reverts commit d0b6a7065146de333536d07274aa5ad842d449d1.

We need this deprecated format in order to support Python 3.8
