### PR TITLE
Improve sapling behavior with devel packages

### DIFF
--- a/alibuild_helpers/sl.py
+++ b/alibuild_helpers/sl.py
@@ -20,9 +20,22 @@ class Sapling(SCM):
     return sapling(("whereami", ), directory)
 
   def branchOrRef(self, directory):
-    # Format is <hash>[+] <branch>
-    identity = sapling(("identify", ), directory)
-    return identity.split(" ")[-1]
+    # Format is * branch     ref or nothing
+    err, output = getstatusoutput("""\
+    set -e +x
+    sl -R {directory} bookmark -r . 2>/dev/null
+    """.format(
+        directory=quote(directory),
+    ), timeout=SL_COMMAND_TIMEOUT_SEC)
+    if err != 0:
+        raise SCMError("Error {} from sl bookmark -r . : {}".format(err, output))
+    # We use "none" to indicate there are no bookmarks. This means 
+    # that a devel package will act as a single branch, regardless of where we are.
+    if not output.strip():
+      return "none"
+    # If a bookmark is there, we use it to determine that we should rebuild
+    # when we move to it
+    return output.split(" ")[2]
 
   def exec(self, *args, **kwargs):
     return sapling(*args, **kwargs)


### PR DESCRIPTION

* If no bookmarks are found, consider always the same branchOrRef,
  as if you where on a branch called "none".
* If a bookmark is there, use the bookmark as identifier for branchOrRef.
