### PR TITLE
Fix track_env command execution in aliBuild init

### DIFF
--- a/alibuild_helpers/init.py
+++ b/alibuild_helpers/init.py
@@ -3,6 +3,7 @@ from alibuild_helpers.utilities import getPackageList, parseDefaults, readDefaul
 from alibuild_helpers.log import debug, error, warning, banner, info
 from alibuild_helpers.log import dieOnError
 from alibuild_helpers.workarea import updateReferenceRepoSpec
+from alibuild_helpers.cmd import getstatusoutput
 
 from os.path import join
 import os.path as path
@@ -54,7 +55,7 @@ def doInit(args):
                                          architecture="",
                                          disable=[],
                                          defaults=args.defaults,
-                                         performPreferCheck=lambda *x, **y: (1, ""),
+                                         performPreferCheck=lambda pkg, cmd: getstatusoutput(["bash", "-c", cmd]),
                                          performRequirementCheck=lambda *x, **y: (0, ""),
                                          performValidateDefaults=lambda spec : validateDefaults(spec, args.defaults),
                                          overrides=overrides,


### PR DESCRIPTION
The performPreferCheck function in init.py was hardcoded to always return
(1, "") which caused all track_env commands to fail during initialization.

Fixes error: "Error while executing track_env for O2PhysicsO2PHYSICS_COMPONENTS: echo
${O2PHYSICS_COMPONENTS:-install} =>"

Regression spotted in alisw/alidist#5888

CC @ktf @fjonasALICE

Current output from master:

```
❯ aliBuild init O2Physics@master
WARNING: using existing recipes from ./alidist
ERROR: Error while executing track_env for O2PhysicsO2PHYSICS_COMPONENTS: echo ${O2PHYSICS_COMPONENTS:-install} =>
```

from this PR:

```
❮ ./aliBuild init O2Physics@master
WARNING: using existing recipes from ./alidist

==> Development directory . created for o2physics
```