### PR TITLE
Fix '.format()' issue with 'find' {} placeholder (double braces addition)

### DIFF
--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -360,7 +360,7 @@ class CVMFSRemoteSync:
       # Create the dummy tarball, if it does not exists
       test -f "{workDir}/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball" && continue
       mkdir -p "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}"
-      find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -name etc -maxdepth 1 -mindepth 1 -exec ln -sf {} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \\;
+      find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -name etc -maxdepth 1 -mindepth 1 -exec ln -sf {{}} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \\;
       cp -fr "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version/etc" "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/etc"
       mkdir -p "{workDir}/TARS/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash"
       tar -C "{workDir}/INSTALLROOT/$pkg_hash" -czf "{workDir}/TARS/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball" .


### PR DESCRIPTION
In `sync.py` (fetch_symlinks), Python's `.format()` interprets {} as a placeholder and tries to replace it with a positional argument at index 0. This causes the command string to be processed incorrectly before reaching bash. 

The braces are intended for `find`, where {} instead should be replaced on runtime by the returned path.

Suggested solution is to add double braces  to `find`, so {} passes literally and the command can interpret it correctly.
```
find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -name etc -maxdepth 1 -mindepth 1 -exec ln -sf {{}} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \\;
```

----

_Local error log:_
```
==> Updating repositories: done  

==> Fetching available build hashes for defaults-release, from /cvmfs/sft-nightlies-test.cern.ch/lcg/bits/
Traceback (most recent call last):
  File "/home/mfolina/workspace/bits/.venv/bin/bitsBuild", line 148, in <module>
    doMain(args, parser)
    ~~~~~~^^^^^^^^^^^^^^
  File "/home/mfolina/workspace/bits/.venv/bin/bitsBuild", line 95, in doMain
    doBuild(args, parser)
    ~~~~~~~^^^^^^^^^^^^^^
  File "/home/mfolina/workspace/bits/bits_helpers/build.py", line 1618, in doBuild
    syncHelper.fetch_symlinks(spec)
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/mfolina/workspace/bits/bits_helpers/sync.py", line 482, in fetch_symlinks
    """.format(
        ~~~~~~^
      workDir=self.workdir,
      ^^^^^^^^^^^^^^^^^^^^^
    ...<4 lines>...
      links_path=links_path,
      ^^^^^^^^^^^^^^^^^^^^^^
    ))
    ^
IndexError: Replacement index 0 out of range for positional args tuple
```