### PR TITLE
Find (sync/fetch_symlinks): Fix escaped slashes \\ and resolve warning by re-ordering arguments

### DIFF
--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -360,7 +360,7 @@ class CVMFSRemoteSync:
       # Create the dummy tarball, if it does not exists
       test -f "{workDir}/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball" && continue
       mkdir -p "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}"
-      find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -name etc -maxdepth 1 -mindepth 1 -exec ln -sf {{}} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \\;
+      find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -name etc -maxdepth 1 -mindepth 1 -exec ln -sf {} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \;
       cp -fr "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version/etc" "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/etc"
       mkdir -p "{workDir}/TARS/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash"
       tar -C "{workDir}/INSTALLROOT/$pkg_hash" -czf "{workDir}/TARS/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball" .

--- a/alibuild_helpers/sync.py
+++ b/alibuild_helpers/sync.py
@@ -349,7 +349,7 @@ class CVMFSRemoteSync:
     # Exit without error in case we do not have any package published
     test -d "{remote_store}/{cvmfs_architecture}/Packages/{package}" || exit 0
     mkdir -p "{workDir}/{links_path}"
-    for install_path in $(find "{remote_store}/{cvmfs_architecture}/Packages/{package}" -type d -mindepth 1 -maxdepth 1); do
+    for install_path in $(find "{remote_store}/{cvmfs_architecture}/Packages/{package}" -mindepth 1 -maxdepth 1 -type d); do
       full_version="${{install_path##*/}}"
       tarball={package}-$full_version.{architecture}.tar.gz
       pkg_hash=$(cat "${{install_path}}/.build-hash" || jq -r '.package.hash' <${{install_path}}/.meta.json)
@@ -360,7 +360,7 @@ class CVMFSRemoteSync:
       # Create the dummy tarball, if it does not exists
       test -f "{workDir}/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball" && continue
       mkdir -p "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}"
-      find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -name etc -maxdepth 1 -mindepth 1 -exec ln -sf {} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \;
+      find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" -mindepth 1 -maxdepth 1 ! -name etc -exec ln -sf {{}} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \;
       cp -fr "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version/etc" "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/etc"
       mkdir -p "{workDir}/TARS/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash"
       tar -C "{workDir}/INSTALLROOT/$pkg_hash" -czf "{workDir}/TARS/{architecture}/store/${{pkg_hash:0:2}}/$pkg_hash/$tarball" .


### PR DESCRIPTION
In sync.py (fetch_symlinks), the escaping for the -exec action leads to error. By putting `\\` in bash, the slash is escaped, leading to the semicolon not being escaped. The following error occures:
```
2026-04-21@16:12:16:DEBUG:LCG:lzma:0: + find /cvmfs/sft-nightlies-test.cern.ch/lcg/bits//x86_64-el9-clang16-dbg/Packages/lzma/v5.2.3-1 '!' -name etc -maxdepth 1 -mindepth 1 -exec ln -sf '{}' ../sw/INSTALLROOT/9f84acd6d95cabaee476830ea5f3d0fbf2c74757/x86_64-el9-clang16-dbg/lzma/ '\'
2026-04-21@16:12:16:DEBUG:LCG:lzma:0: find: missing argument to `-exec'
```
Suggested solution here is updating `\\;` to `\;`:
```diff
-     find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -name etc -maxdepth 1 -mindepth 1 -exec ln -sf {{}} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \\;
+     find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -name etc -maxdepth 1 -mindepth 1 -exec ln -sf {{}} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \;
```

Additionally, a warning appears regarding the order of the arguments that `find` uses.  The current argument order should be updated with the logic that `-mindepth` and `-maxdepth` should be before `!` and before `-type`.
```Log
2026-04-22@17:58:41:DEBUG:lzma:lzma:0: + find /cvmfs/sft-nightlies-test.cern.ch/lcg/bits/x86_64-el10-gcc15-opt/Packages/lzma/v5.2.3-1 '!' -name etc -maxdepth 1 -mindepth 1 -exec ln -sf '{}' sw/INSTALLROOT/b75f1aa911fd6e55a521af6ed3168ed529706bb1/x86_64-el10-gcc15-opt/lzma/ ';'
2026-04-22@17:58:41:DEBUG:lzma:lzma:0: find: warning: you have specified the global option -maxdepth after the argument !, but global options are not positional, i.e., -maxdepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
2026-04-22@17:58:41:DEBUG:lzma:lzma:0: find: warning: you have specified the global option -mindepth after the argument !, but global options are not positional, i.e., -mindepth affects tests specified before it as well as those specified after it.  Please specify global options before other arguments.
```
Suggested solution is updating both instances of `find` in execute:
```diff
-    for install_path in $(find "{remote_store}/{cvmfs_architecture}/Packages/{package}" -type d -mindepth 1 -maxdepth 1); do
+    for install_path in $(find "{remote_store}/{cvmfs_architecture}/Packages/{package}" -mindepth 1 -maxdepth 1 -type d); do
```
And:
```diff
-     find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" ! -maxdepth 1 -mindepth 1 -name etc -exec ln -sf {{}} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \;
+     find "{remote_store}/{cvmfs_architecture}/Packages/{package}/$full_version" -mindepth 1 -maxdepth 1 ! -name etc -exec ln -sf {{}} "{workDir}/INSTALLROOT/$pkg_hash/{architecture}/{package}/" \;
```